### PR TITLE
set position estimation max log level to Info

### DIFF
--- a/interop/position-estimation_rust/src/jni.rs
+++ b/interop/position-estimation_rust/src/jni.rs
@@ -23,7 +23,10 @@ pub extern "system" fn Java_app_grapheneos_networklocation_interop_position_1est
 ) -> jobject {
     android_logger::init_once(
         Config::default()
-            .with_max_level(log::max_level())
+            // TODO: remove with_max_level once android_logger 0.15.0 or newer ships,
+            // which allows delegating log filtering to liblog when the android-api-30
+            // feature is enabled
+            .with_max_level(log::LevelFilter::Info)
             .with_tag("PositionEstimation"),
     );
 


### PR DESCRIPTION
The version of android_logger that's currently shipped doesn't allow delegating log filtering to liblog. It logs at the set max level, causing slowdowns when that is set to Verbose. 0.15.0 comes with capability to delegate log filtering to liblog when the android-api-30 feature is enabled. We should do that when android_logger gets updated. For now, changing the max log level of position estimation needs to be done through code.