### PR TITLE
implement request batching and increase requested closest APs to 15

### DIFF
--- a/proto/apple_wps.proto
+++ b/proto/apple_wps.proto
@@ -5,6 +5,7 @@ package app.grapheneos.networklocation.proto;
 option java_outer_classname = "AppleWpsProtos";
 
 message Request {
+  // WARNING: Max 5 bssids per request
   repeated BssidWrapper bssid_wrapper = 2;
   // Max number of additional nearby access points that can be included in the response.
   // Should be at least 1, otherwise it defaults to around 400

--- a/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
+++ b/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
@@ -25,31 +25,48 @@ class AppleWifiPositioningService : WifiPositioningService {
     private val tlsSocketFactory = ModernTLSSocketFactory()
 
     @Throws(IOException::class)
-    override fun fetchNearbyApPositioningData(bssid: Bssid, maxResultsHint: Int): List<WifiApPositioningData> {
-        val response = fetchInner(bssid, maxResultsHint)
+    override fun fetchNearbyApPositioningData(
+        bssids: List<String>,
+        maxResultsHint: Int,
+        withPositioningDataThreshold: Int
+    ): List<WifiApPositioningData> {
+        val result = HashMap<Bssid, PositioningData?>()
 
-        val result = mutableListOf<WifiApPositioningData>()
+        // the service only allows up to 5 bssids per request
+        for (requestBssids in bssids.chunked(5)) {
+            val response = fetchInner(requestBssids, maxResultsHint)
 
-        for (ap in response.accessPointList) {
-            val apBssid = normalizeBssid(ap.bssid)
-            if (apBssid == null) {
-                Log.w(TAG, "invalid bssid ${ap.bssid}")
-                continue
+            for (ap in response.accessPointList) {
+                val apBssid = normalizeBssid(ap.bssid)
+                if (apBssid == null) {
+                    Log.w(TAG, "invalid bssid ${ap.bssid}")
+                    continue
+                }
+                result.putIfAbsent(apBssid, convertPositioningData(ap.positioningData))
             }
-            result.add(WifiApPositioningData(apBssid, convertPositioningData(ap.positioningData)))
+            for (bssid in requestBssids) {
+                if (!result.any { it.key == bssid }) {
+                    Log.d(
+                        TAG,
+                        "server didn't return positioning data for one of the requested bssids $bssid"
+                    )
+                    result.putIfAbsent(bssid, null)
+                }
+            }
+
+            if (bssids.count { result[it] != null } >= withPositioningDataThreshold) {
+                break
+            }
         }
-        if (!result.any { it.bssid == bssid }) {
-            Log.d(TAG, "server didn't return positioning data for the requested bssid $bssid")
-            result.add(0, WifiApPositioningData(bssid, positioningData = null))
-        }
-        return result
+
+        return result.map { WifiApPositioningData(it.key, it.value) }
     }
 
     @Throws(IOException::class)
-    private fun fetchInner(bssid: Bssid, maxResultsHint: Int): AppleWpsProtos.Response {
+    private fun fetchInner(bssids: List<Bssid>, maxResultsHint: Int): AppleWpsProtos.Response {
         val (url, enforceModernTls) = getServerUrl()
 
-        verboseLog(TAG) {"request bssid: $bssid"}
+        verboseLog(TAG) {"request bssids: $bssids"}
 
         val connection = url.openConnection() as HttpsURLConnection
         try {
@@ -75,9 +92,13 @@ class AppleWifiPositioningService : WifiPositioningService {
                 )
 
                 val body = AppleWpsProtos.Request.newBuilder().run {
-                    addBssidWrapper(AppleWpsProtos.BssidWrapper.newBuilder().setBssid(bssid).build())
+                    addAllBssidWrapper(bssids.map {
+                        AppleWpsProtos.BssidWrapper.newBuilder()
+                            .setBssid(it)
+                            .build()
+                    })
                     // should be at least 1, otherwise it defaults to around 400
-                    setMaxAdditionalResults(max(1, maxResultsHint - 1))
+                    setMaxAdditionalResults(max(1, maxResultsHint - bssids.size))
                     build()
                 }
 

--- a/src/app/grapheneos/networklocation/wifi/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/wifi/LocationReportingTask.kt
@@ -19,7 +19,6 @@ import app.grapheneos.networklocation.median
 import app.grapheneos.networklocation.rssiToDistance
 import app.grapheneos.networklocation.verboseLog
 import java.io.IOException
-import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -89,25 +88,33 @@ class LocationReportingTask(
     private fun estimateLocation(scanResults: List<ScanResult>): Location? {
         var bestResults = HashMap<Bssid, PositionedScanResult>()
 
-        for (scanResult in scanResults.sortedByDescending { it.level }) {
-            val bssid: Bssid = scanResult.BSSID
+        val positioningData = mutableListOf<WifiApPositioningData>()
 
-            val positioningData = try {
-                // don't make additional network request when there's at least 5 results already
-                val onlyCached = bestResults.size >= 5
-                service.getPositioningData(bssid, onlyCached)
-            } catch (e: IOException) {
-                Log.d(TAG, "unable to obtain positioning data: $e")
-                if (Log.isLoggable(TAG, Log.VERBOSE)) {
-                    Log.v(TAG, "", e)
-                }
-                continue
+        try {
+            val bssids = scanResults.sortedByDescending { it.level }.map { it.BSSID }
+
+            // just in case the potential additional requests fail, add only cached ones
+            positioningData.addAll(service.getPositioningData(bssids, 0))
+
+            // don't make additional requests when we have 15 of the closest results with valid
+            // positioning data already
+            val onlyCachedThreshold = 15
+            val result = service.getPositioningData(bssids, onlyCachedThreshold)
+            positioningData.clear()
+            positioningData.addAll(result)
+        } catch (e: IOException) {
+            Log.d(TAG, "unable to obtain positioning data: $e")
+            if (Log.isLoggable(TAG, Log.VERBOSE)) {
+                Log.v(TAG, "", e)
             }
-            if (positioningData == null) {
-                continue
+        }
+
+        for (data in positioningData) {
+            val scanResult = scanResults.find { it.BSSID == data.bssid }
+            if (scanResult != null && data.positioningData != null) {
+                bestResults[data.bssid] =
+                    PositionedScanResult(scanResult, data.positioningData, null)
             }
-            bestResults[bssid] =
-                PositionedScanResult(scanResult, positioningData, null)
         }
         if (bestResults.isEmpty()) {
             return null

--- a/src/app/grapheneos/networklocation/wifi/WifiPositioningService.kt
+++ b/src/app/grapheneos/networklocation/wifi/WifiPositioningService.kt
@@ -4,7 +4,11 @@ import java.io.IOException
 
 interface WifiPositioningService {
     @Throws(IOException::class)
-    fun fetchNearbyApPositioningData(bssid: String, maxResultsHint: Int): List<WifiApPositioningData>
+    fun fetchNearbyApPositioningData(
+        bssids: List<String>,
+        maxResultsHint: Int,
+        withPositioningDataThreshold: Int
+    ): List<WifiApPositioningData>
 }
 
 class WifiApPositioningData(

--- a/src/app/grapheneos/networklocation/wifi/WifiPositioningServiceCache.kt
+++ b/src/app/grapheneos/networklocation/wifi/WifiPositioningServiceCache.kt
@@ -32,20 +32,41 @@ class WifiPositioningServiceCache(private val service: WifiPositioningService) {
     }
 
     @Throws(IOException::class)
-    fun getPositioningData(bssid: Bssid, onlyCached: Boolean): PositioningData? {
+    fun getPositioningData(
+        bssids: List<Bssid>,
+        onlyCachedThreshold: Int,
+    ): List<WifiApPositioningData> {
         val isVerbose = Log.isLoggable(TAG, Log.VERBOSE)
-        checkCache(bssid)?.let {
-            val res = it.orElse(null)
-            if (isVerbose) Log.v(TAG, "getPositioningData: cache hit for $bssid: $res")
-            return res
+        val positioningData = mutableListOf<WifiApPositioningData>()
+        val queryBssids = mutableListOf<Bssid>()
+
+        for (bssid in bssids) {
+            val cacheEntry = checkCache(bssid)
+            if (cacheEntry != null) {
+                val res = cacheEntry.orElse(null)
+                if (isVerbose) Log.v(
+                    TAG,
+                    "getPositioningData: cache hit for $bssid: $res"
+                )
+                if (res != null) {
+                    positioningData.add(WifiApPositioningData(bssid, res))
+                }
+            } else if (positioningData.size < onlyCachedThreshold || queryBssids.isNotEmpty()) {
+                queryBssids.add(bssid)
+            }
         }
 
-        if (onlyCached) {
-            return null
+        if (queryBssids.isEmpty()) {
+            return positioningData
         }
 
-        if (isVerbose) Log.v(TAG, "querying positioning data for $bssid")
-        val apInfos: List<WifiApPositioningData> = service.fetchNearbyApPositioningData(bssid, MAX_RESPONSE_SIZE)
+        if (isVerbose) Log.v(TAG, "querying positioning data for $queryBssids")
+        val apInfos: List<WifiApPositioningData> =
+            service.fetchNearbyApPositioningData(
+                queryBssids,
+                MAX_RESPONSE_SIZE,
+                onlyCachedThreshold
+            )
         if (isVerbose) Log.v(TAG, "service response: $apInfos")
 
         if (apInfos.size > MAX_RESPONSE_SIZE) {
@@ -59,13 +80,21 @@ class WifiPositioningServiceCache(private val service: WifiPositioningService) {
                     return@forEachIndexed
                 }
             }
-            checkCache(bssid)?.let {
-                return it.orElse(null)
+            for ((index, bssid) in queryBssids.withIndex()) {
+                val cacheEntry = checkCache(bssid)
+                if (cacheEntry != null) {
+                    val res = cacheEntry.orElse(null)
+                    res?.let { positioningData.add(WifiApPositioningData(bssid, it)) }
+                } else if (index <= onlyCachedThreshold) {
+                    Log.w(
+                        TAG,
+                        "cache lookup for $bssid failed after service.fetchAccessPointInfo()"
+                    )
+                }
             }
         }
 
-        Log.w(TAG, "cache lookup failed after service.fetchAccessPointInfo()")
-        return null
+        return positioningData
     }
 
     private fun checkCache(bssid: Bssid): Optional<PositioningData>? {


### PR DESCRIPTION
Batches in chunks of 5 because Apple's server doesn't return a valid response when we ask for more.

We will now request the closest APs to us in the scan (determined by RSSI) until we have 15 with valid positioning data, or we run out of APs to request.