### PR TITLE
add throttling to requesting MAX_ADDITIONAL_RESULTS

### DIFF
--- a/proto/apple_wps.proto
+++ b/proto/apple_wps.proto
@@ -10,10 +10,9 @@ message Request {
   // Max number of additional nearby access points that can be included in the response.
   // Should be at least 1, otherwise it defaults to around 400
   int32 max_additional_results = 4;
+  repeated int64 unknown_31 = 31;
   // when set to 1, reverts altitude behavior to where you don't have to divide it
   // and altitude accuracy by 100 to get the real values
-//  int64 unknown_30 = 30;
-  repeated int64 unknown_31 = 31;
   int64 unknown_32 = 32;
   DeviceInfo device_info = 33;
 }

--- a/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
+++ b/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
@@ -6,6 +6,7 @@ import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_DISABLED
 import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SERVER_APPLE
 import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SERVER_GRAPHENEOS_PROXY
 import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SETTING
+import android.os.SystemClock
 import android.util.Log
 import app.grapheneos.networklocation.proto.AppleWpsProtos
 import app.grapheneos.networklocation.proto.AppleWpsProtos.DeviceInfo
@@ -15,17 +16,23 @@ import java.net.HttpURLConnection
 import java.net.URL
 import javax.net.ssl.HttpsURLConnection
 import kotlin.math.max
-import kotlin.Pair
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import org.grapheneos.tls.ModernTLSSocketFactory
 
 private const val TAG = "AppleWps"
 private const val EXTRA_VERBOSE_TAG = "AppleWpsVV"
 
+private const val THROTTLED_ADDITIONAL_RESULTS = 8
 private const val MAX_ADDITIONAL_RESULTS = 100
+private val THROTTLE_COOLDOWN = 10.seconds
+private const val THROTTLE_TRIGGER_RESULT_COUNT = 17
 
 class AppleWifiPositioningService : WifiPositioningService {
 
     private val tlsSocketFactory = ModernTLSSocketFactory()
+
+    private var throttleTriggeredElapsedRealtime = -THROTTLE_COOLDOWN
 
     @Throws(IOException::class)
     override fun fetchNearbyApPositioningData(
@@ -41,7 +48,19 @@ class AppleWifiPositioningService : WifiPositioningService {
             val currentRequestBssids = requestBssids.take(4)
             requestBssids.removeAll(currentRequestBssids)
 
-            val response = fetchInner(currentRequestBssids, MAX_ADDITIONAL_RESULTS)
+            val response = fetchInner(
+                currentRequestBssids,
+                if (SystemClock.elapsedRealtime().milliseconds - throttleTriggeredElapsedRealtime >= THROTTLE_COOLDOWN) {
+                    MAX_ADDITIONAL_RESULTS
+                } else {
+                    THROTTLED_ADDITIONAL_RESULTS
+                }
+            )
+
+            if (response.accessPointCount >= THROTTLE_TRIGGER_RESULT_COUNT) {
+                verboseLog(TAG) { "response AP count (${response.accessPointCount}) triggered throttle" }
+                throttleTriggeredElapsedRealtime = SystemClock.elapsedRealtime().milliseconds
+            }
 
             for (ap in response.accessPointList) {
                 val apBssid = normalizeBssid(ap.bssid)


### PR DESCRIPTION
Throttle gets triggered after a response returning 17 or more APs. It has a cooldown of 10 seconds, where THROTTLED_ADDITIONAL_RESULTS is requested instead.