### PR TITLE
Cell-based location support

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.INSTALL_LOCATION_PROVIDER" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.LOCATION_HARDWARE" />
+    <uses-permission android:name="android.permission.MODIFY_PHONE_STATE" />
     <uses-permission android:name="android.permission.UPDATE_DEVICE_STATS" />
 
     <application

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.LOCATION_HARDWARE" />
     <uses-permission android:name="android.permission.MODIFY_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.UPDATE_DEVICE_STATS" />
 
     <application

--- a/etc/permissions/app.grapheneos.networklocation.xml
+++ b/etc/permissions/app.grapheneos.networklocation.xml
@@ -3,6 +3,7 @@
     <privapp-permissions package="app.grapheneos.networklocation">
         <permission name="android.permission.INSTALL_LOCATION_PROVIDER" />
         <permission name="android.permission.LOCATION_HARDWARE" />
+        <permission name="android.permission.MODIFY_PHONE_STATE" />
         <permission name="android.permission.UPDATE_DEVICE_STATS" />
     </privapp-permissions>
 </permissions>

--- a/proto/apple_wps.proto
+++ b/proto/apple_wps.proto
@@ -5,9 +5,9 @@ package app.grapheneos.networklocation.proto;
 option java_outer_classname = "AppleWpsProtos";
 
 message ALSLocationRequest {
-  repeated CellTower cell_towers = 1;
+  repeated GsmCellTower gsm_cell_towers = 1;
   repeated WirelessAP wireless_aps = 2;
-  optional int32 number_of_surrounding_cells = 3;
+  optional int32 number_of_surrounding_gsm_cells = 3;
   optional int32 number_of_surrounding_wifis = 4;
 
   optional string app_bundle_id = 5;
@@ -50,7 +50,7 @@ message ALSLocationRequest {
 }
 
 message ALSLocationResponse {
-  repeated CellTower cell_towers = 1;
+  repeated GsmCellTower gsm_cell_towers = 1;
   repeated WirelessAP wireless_aps = 2;
 
   repeated CdmaCellTower cdma_cell_towers = 21;
@@ -73,7 +73,7 @@ message ALSLocation {
   optional uint32 info_mask = 13;
 }
 
-message CellTower {
+message GsmCellTower {
   int32 mcc = 1;
   int32 mnc = 2;
   int32 cell_id = 3;

--- a/proto/apple_wps.proto
+++ b/proto/apple_wps.proto
@@ -137,7 +137,7 @@ message ScdmaCellTower {
 message Nr5GCellTower {
   optional int32 mcc = 1;
   optional int32 mnc = 2;
-  optional int32 cell_id = 3;
+  optional int64 cell_id = 3;
   optional int32 tac_id = 4;
   optional ALSLocation location = 5;
   optional int32 nrarfcn = 6;

--- a/src/app/grapheneos/networklocation/ApplePositioningService.kt
+++ b/src/app/grapheneos/networklocation/ApplePositioningService.kt
@@ -1,0 +1,108 @@
+package app.grapheneos.networklocation
+
+import android.app.AppGlobals
+import android.content.Context
+import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_DISABLED
+import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SERVER_APPLE
+import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SERVER_GRAPHENEOS_PROXY
+import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SETTING
+import android.util.Log
+import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationRequest
+import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationRequest.ALSMeta
+import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationResponse
+import java.io.DataOutputStream
+import java.io.IOException
+import java.net.URL
+import javax.net.ssl.HttpsURLConnection
+import org.grapheneos.tls.ModernTLSSocketFactory
+
+private const val TAG = "ApplePs"
+private const val EXTRA_VERBOSE_TAG = "ApplePsVV"
+
+class ApplePositioningService {
+    val macosMeta: ALSMeta = ALSMeta.newBuilder()
+        .setSoftwareBuild("macOS15.4/24E248")
+        .setProductId("arm64")
+        .build()
+
+    private val tlsSocketFactory = ModernTLSSocketFactory()
+
+    @Throws(IOException::class)
+    fun fetch(request: ALSLocationRequest): ALSLocationResponse {
+        val (url, enforceModernTls) = getServerUrl()
+
+        val connection = url.openConnection() as HttpsURLConnection
+        try {
+            if (enforceModernTls) {
+                connection.sslSocketFactory = tlsSocketFactory
+            }
+            connection.requestMethod = "POST"
+            connection.setRequestProperty("Accept", "*/*")
+            connection.setRequestProperty("Accept-Language", "en-US,en;q=0.9")
+            connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
+            connection.setRequestProperty(
+                "User-Agent",
+                "locationd/2960.0.57 CFNetwork/3826.500.111.1.1 Darwin/24.4.0"
+            )
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 10_000
+            connection.doOutput = true
+
+            DataOutputStream(connection.outputStream).use { outputStream ->
+                val locale = "en-US_US".toByteArray()
+                val identifier = "com.apple.locationd".toByteArray()
+                val version = "15.4.24E248".toByteArray()
+                val requestCode = 1
+
+                outputStream.writeShort(1) // hardcoded
+                outputStream.writeShort(locale.size)
+                outputStream.write(locale)
+                outputStream.writeShort(identifier.size)
+                outputStream.write(identifier)
+                outputStream.writeShort(version.size)
+                outputStream.write(version)
+                outputStream.writeInt(requestCode)
+
+                outputStream.writeInt(request.serializedSize)
+                request.writeTo(outputStream)
+            }
+
+            val responseCode = connection.responseCode
+            if (responseCode != HttpsURLConnection.HTTP_OK) {
+                throw IOException("non-200 response code: $responseCode")
+            }
+            val ignoredHeaderSize = 10
+            val protoBytes: ByteArray = connection.inputStream.use { inputStream ->
+                inputStream.skipNBytes(ignoredHeaderSize.toLong())
+                inputStream.readAllBytes()
+            }
+            val response = ALSLocationResponse.parseFrom(protoBytes)
+            verboseLog(TAG) {
+                "byte size: ${protoBytes.size + ignoredHeaderSize}"
+            }
+            if (Log.isLoggable(EXTRA_VERBOSE_TAG, Log.VERBOSE)) {
+                Log.v(EXTRA_VERBOSE_TAG, "response headers: " + connection.headerFields)
+            }
+            return response
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    @Throws(IOException::class)
+    private fun getServerUrl(): Pair<URL, Boolean> {
+        val context: Context = AppGlobals.getInitialApplication()
+        val setting = NETWORK_LOCATION_SETTING.get(context)
+        return when (setting) {
+            NETWORK_LOCATION_SERVER_GRAPHENEOS_PROXY ->
+                Pair(URL("https://gs-loc.apple.grapheneos.org/clls/wloc"), true)
+            NETWORK_LOCATION_SERVER_APPLE ->
+                Pair(URL("https://gs-loc.apple.com/clls/wloc"), false)
+            NETWORK_LOCATION_DISABLED ->
+                // network location can be disabled by the user at any point
+                throw IOException("network location setting became disabled")
+            else ->
+                throw IllegalStateException("unexpected URL setting: $setting")
+        }
+    }
+}

--- a/src/app/grapheneos/networklocation/LocationProviderImpl.kt
+++ b/src/app/grapheneos/networklocation/LocationProviderImpl.kt
@@ -8,6 +8,9 @@ import android.location.provider.ProviderProperties
 import android.location.provider.ProviderRequest
 import android.os.Bundle
 import android.util.Log
+import app.grapheneos.networklocation.cell.AppleCellPositioningService
+import app.grapheneos.networklocation.cell.CellPositioningServiceCache
+import app.grapheneos.networklocation.cell.CellTowerScanner
 import app.grapheneos.networklocation.wifi.AppleWifiPositioningService
 import app.grapheneos.networklocation.wifi.WifiApRanger
 import app.grapheneos.networklocation.wifi.WifiApScanner
@@ -21,11 +24,14 @@ import kotlinx.coroutines.runBlocking
 
 private const val TAG = "LocationProviderImpl"
 
-// Reuse cache across NetworkLocationProvider instances to reduce latency and network usage. Note
-// that the cache is periodically cleaned up to prevent recording long location history, see
+// Reuse caches across NetworkLocationProvider instances to reduce latency and network usage. Note
+// that the caches are periodically cleaned up to prevent recording long location history, see
 // TimedLruCache.scheduleClean()
 private val wifiPositioningServiceCache by lazy {
     WifiPositioningServiceCache(AppleWifiPositioningService())
+}
+private val cellPositioningServiceCache by lazy {
+    CellPositioningServiceCache(AppleCellPositioningService())
 }
 
 class LocationProviderImpl(private val context: Context)
@@ -58,6 +64,8 @@ class LocationProviderImpl(private val context: Context)
                 WifiApScanner(context),
                 WifiApRanger(context),
                 wifiPositioningServiceCache,
+                CellTowerScanner(context),
+                cellPositioningServiceCache,
             )
             locationReportingJob = CoroutineScope(Dispatchers.IO).launch {
                 task.run()

--- a/src/app/grapheneos/networklocation/LocationProviderImpl.kt
+++ b/src/app/grapheneos/networklocation/LocationProviderImpl.kt
@@ -9,7 +9,6 @@ import android.location.provider.ProviderRequest
 import android.os.Bundle
 import android.util.Log
 import app.grapheneos.networklocation.wifi.AppleWifiPositioningService
-import app.grapheneos.networklocation.wifi.LocationReportingTask
 import app.grapheneos.networklocation.wifi.WifiApRanger
 import app.grapheneos.networklocation.wifi.WifiApScanner
 import app.grapheneos.networklocation.wifi.WifiPositioningServiceCache

--- a/src/app/grapheneos/networklocation/LocationProviderImpl.kt
+++ b/src/app/grapheneos/networklocation/LocationProviderImpl.kt
@@ -23,7 +23,7 @@ private const val TAG = "LocationProviderImpl"
 
 // Reuse cache across NetworkLocationProvider instances to reduce latency and network usage. Note
 // that the cache is periodically cleaned up to prevent recording long location history, see
-// WifiPositioningServiceCache.scheduleClean()
+// TimedLruCache.scheduleClean()
 private val wifiPositioningServiceCache by lazy {
     WifiPositioningServiceCache(AppleWifiPositioningService())
 }

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -13,6 +13,8 @@ import android.telephony.CellIdentityWcdma
 import android.telephony.CellInfo
 import android.util.Log
 import app.grapheneos.networklocation.cell.CellPositioningServiceCache
+import app.grapheneos.networklocation.cell.CellScanFailedException
+import app.grapheneos.networklocation.cell.CellScannerUnavailableException
 import app.grapheneos.networklocation.cell.CellTowerPositioningData
 import app.grapheneos.networklocation.cell.CellTowerScanner
 import app.grapheneos.networklocation.cell.Identifier
@@ -73,14 +75,36 @@ class LocationReportingTask(
                 is WifiScannerUnavailableException, is WifiScanFailedException -> {
                     // stack trace is intentionally omitted, it doesn't contain useful info
                     Log.d(TAG, e.toString())
+                    null
+                }
+
+                else -> throw e
+            }
+        }
+        if (scanResults != null) {
+            val location = estimateLocationWifi(scanResults)
+            verboseLog(TAG) { "estimateLocationWifi returned $location" }
+            if (location != null) {
+                provider.reportLocation(location)
+                return
+            }
+        }
+        verboseLog(TAG) { "falling back to cell-tower-based location" }
+        val cellInfos = try {
+            cellScanner.scan(request.workSource)
+        } catch (e: Exception) {
+            when (e) {
+                is CellScannerUnavailableException, is CellScanFailedException -> {
+                    // stack trace is intentionally omitted, it doesn't contain useful info
+                    Log.d(TAG, e.toString())
                     return
                 }
 
                 else -> throw e
             }
         }
-        val location = estimateLocationWifi(scanResults)
-        verboseLog(TAG) { "estimateLocation returned $location" }
+        val location = estimateLocationCell(cellInfos)
+        verboseLog(TAG) { "estimateLocationCell returned $location" }
         if (location != null) {
             provider.reportLocation(location)
         }

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -12,7 +12,6 @@ import app.grapheneos.networklocation.interop.position_estimation.Measurement
 import app.grapheneos.networklocation.interop.position_estimation.Position
 import app.grapheneos.networklocation.interop.position_estimation.PositionEstimation
 import app.grapheneos.networklocation.wifi.Bssid
-import app.grapheneos.networklocation.wifi.PositioningData
 import app.grapheneos.networklocation.wifi.WifiApPositioningData
 import app.grapheneos.networklocation.wifi.WifiApRanger
 import app.grapheneos.networklocation.wifi.WifiApScanner

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -70,7 +70,7 @@ class LocationReportingTask(
                 else -> throw e
             }
         }
-        val location = estimateLocation(scanResults)
+        val location = estimateLocationWifi(scanResults)
         verboseLog(TAG) { "estimateLocation returned $location" }
         if (location != null) {
             provider.reportLocation(location)
@@ -89,7 +89,7 @@ class LocationReportingTask(
         var estimatedDistance: EstimatedDistance?,
     )
 
-    private fun estimateLocation(scanResults: List<ScanResult>): Location? {
+    private fun estimateLocationWifi(scanResults: List<ScanResult>): Location? {
         var bestResults = HashMap<Bssid, PositionedScanResult>()
 
         val allPositioningData = mutableListOf<WifiApPositioningData>()

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -7,6 +7,8 @@ import android.location.provider.ProviderRequest
 import android.net.wifi.ScanResult
 import android.os.SystemClock
 import android.util.Log
+import app.grapheneos.networklocation.cell.CellPositioningServiceCache
+import app.grapheneos.networklocation.cell.CellTowerScanner
 import app.grapheneos.networklocation.interop.position_estimation.Coordinate
 import app.grapheneos.networklocation.interop.position_estimation.Measurement
 import app.grapheneos.networklocation.interop.position_estimation.Position
@@ -31,9 +33,11 @@ private const val TAG = "LocationReportingTask"
 class LocationReportingTask(
     private val provider: LocationProviderBase,
     private val request: ProviderRequest,
-    private val scanner: WifiApScanner,
-    private val ranger: WifiApRanger,
-    private val service: WifiPositioningServiceCache,
+    private val wifiScanner: WifiApScanner,
+    private val wifiRanger: WifiApRanger,
+    private val wifiService: WifiPositioningServiceCache,
+    private val cellScanner: CellTowerScanner,
+    private val cellService: CellPositioningServiceCache,
 ) {
     suspend fun run() {
         val interval = max(1000, request.intervalMillis)
@@ -54,7 +58,7 @@ class LocationReportingTask(
 
     private suspend fun step() {
         val scanResults = try {
-            scanner.scan(request.workSource)
+            wifiScanner.scan(request.workSource)
         } catch (e: Exception) {
             when (e) {
                 is WifiScannerUnavailableException, is WifiScanFailedException -> {
@@ -94,12 +98,12 @@ class LocationReportingTask(
             val bssids = scanResults.sortedByDescending { it.level }.map { it.BSSID }
 
             // just in case the potential additional requests fail, add only cached ones
-            allPositioningData.addAll(service.getPositioningData(bssids, 0))
+            allPositioningData.addAll(wifiService.getPositioningData(bssids, 0))
 
             // don't make additional requests when we have 15 of the closest results with valid
             // positioning data already
             val onlyCachedThreshold = 15
-            val result = service.getPositioningData(bssids, onlyCachedThreshold)
+            val result = wifiService.getPositioningData(bssids, onlyCachedThreshold)
             allPositioningData.clear()
             allPositioningData.addAll(result)
         } catch (e: IOException) {
@@ -124,7 +128,7 @@ class LocationReportingTask(
             // TODO: use Wi-Fi RTT to estimate distance with RSSI as a fallback
 //            try {
 //                // TODO: maybe handle the fact that the max results this can return is 10
-//                ranger.range(bestResults.values.map { it.scanResult }, request.workSource)
+//                wifiRanger.range(bestResults.values.map { it.scanResult }, request.workSource)
 //                    .map { rangingResult ->
 //                        // TODO: handle one-sided RTT correctly
 //                        // use absolute value to counter negative distance values in cases of

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -6,9 +6,17 @@ import android.location.provider.LocationProviderBase
 import android.location.provider.ProviderRequest
 import android.net.wifi.ScanResult
 import android.os.SystemClock
+import android.telephony.CellIdentityGsm
+import android.telephony.CellIdentityLte
+import android.telephony.CellIdentityNr
+import android.telephony.CellIdentityWcdma
+import android.telephony.CellInfo
 import android.util.Log
 import app.grapheneos.networklocation.cell.CellPositioningServiceCache
+import app.grapheneos.networklocation.cell.CellTowerPositioningData
 import app.grapheneos.networklocation.cell.CellTowerScanner
+import app.grapheneos.networklocation.cell.Identifier
+import app.grapheneos.networklocation.cell.Standard
 import app.grapheneos.networklocation.interop.position_estimation.Coordinate
 import app.grapheneos.networklocation.interop.position_estimation.Measurement
 import app.grapheneos.networklocation.interop.position_estimation.Position
@@ -25,6 +33,7 @@ import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.sqrt
 import kotlin.time.Duration.Companion.microseconds
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
@@ -87,6 +96,11 @@ class LocationReportingTask(
         val scanResult: ScanResult,
         val positioningData: PositioningData,
         var estimatedDistance: EstimatedDistance?,
+    )
+
+    private class PositionedCellInfo(
+        val cellInfo: CellInfo,
+        val positioningData: PositioningData,
     )
 
     private fun estimateLocationWifi(scanResults: List<ScanResult>): Location? {
@@ -248,6 +262,228 @@ class LocationReportingTask(
 
         loc.elapsedRealtimeNanos =
             bestResults.values.minOf { it.scanResult.timestamp }.microseconds.inWholeNanoseconds
+        val locationAgeMillis =
+            SystemClock.elapsedRealtime() - loc.elapsedRealtimeNanos / 1_000_000L
+        loc.time = max(0L, System.currentTimeMillis() - locationAgeMillis)
+
+        val enuPoint = Point(result.x.value, result.y.value, result.z.value)
+        val estimatedGeoPoint = enuPointToGeoPoint(enuPoint, refGeoPoint)
+        loc.longitude = estimatedGeoPoint.longitude
+        loc.latitude = estimatedGeoPoint.latitude
+        loc.accuracy = ((sqrt(result.x.variance) + sqrt(result.y.variance)) / 2.0).toFloat()
+        estimatedGeoPoint.altitude?.let { estimatedAltitude ->
+            loc.altitude = estimatedAltitude
+            loc.verticalAccuracyMeters = sqrt(result.z.variance).toFloat()
+        }
+        return loc
+    }
+
+    private fun estimateLocationCell(cellInfos: List<CellInfo>): Location? {
+        val bestResults = HashMap<Identifier, PositionedCellInfo>()
+
+        val identifiers = cellInfos.mapNotNull {
+            val mcc = it.cellIdentity.mccString?.toIntOrNull() ?: return@mapNotNull null
+            val mnc = it.cellIdentity.mncString?.toIntOrNull() ?: return@mapNotNull null
+
+            val identifier = when (it.cellIdentity) {
+                is CellIdentityNr -> {
+                    val identity = it.cellIdentity as CellIdentityNr
+                    Identifier(
+                        Standard.NR,
+                        mcc,
+                        mnc,
+                        identity.tac.let { tac ->
+                            if (tac != CellInfo.UNAVAILABLE) {
+                                tac
+                            } else {
+                                return@mapNotNull null
+                            }
+                        },
+                        identity.nci.let { nci ->
+                            if (nci != CellInfo.UNAVAILABLE_LONG) {
+                                nci
+                            } else {
+                                return@mapNotNull null
+                            }
+                        }
+                    )
+                }
+
+                is CellIdentityLte -> {
+                    val identity = it.cellIdentity as CellIdentityLte
+                    Identifier(
+                        Standard.LTE,
+                        mcc,
+                        mnc,
+                        identity.tac.let { tac ->
+                            if (tac != CellInfo.UNAVAILABLE) {
+                                tac
+                            } else {
+                                return@mapNotNull null
+                            }
+                        },
+                        identity.ci.let { cellId ->
+                            if (cellId != CellInfo.UNAVAILABLE) {
+                                cellId
+                            } else {
+                                return@mapNotNull null
+                            }.toLong()
+                        }
+                    )
+                }
+
+                is CellIdentityWcdma -> {
+                    val identity = it.cellIdentity as CellIdentityWcdma
+                    Identifier(
+                        Standard.WCDMA,
+                        mcc,
+                        mnc,
+                        identity.lac.let { lac ->
+                            if (lac != CellInfo.UNAVAILABLE) {
+                                lac
+                            } else {
+                                return@mapNotNull null
+                            }
+                        },
+                        identity.cid.let { cellId ->
+                            if (cellId != CellInfo.UNAVAILABLE) {
+                                cellId
+                            } else {
+                                return@mapNotNull null
+                            }.toLong()
+                        }
+                    )
+                }
+
+                is CellIdentityGsm -> {
+                    val identity = it.cellIdentity as CellIdentityGsm
+                    Identifier(
+                        Standard.GSM,
+                        mcc,
+                        mnc,
+                        identity.lac.let { lac ->
+                            if (lac != CellInfo.UNAVAILABLE) {
+                                lac
+                            } else {
+                                return@mapNotNull null
+                            }
+                        },
+                        identity.cid.let { cellId ->
+                            if (cellId != CellInfo.UNAVAILABLE) {
+                                cellId
+                            } else {
+                                return@mapNotNull null
+                            }.toLong()
+                        }
+                    )
+                }
+
+                else -> return@mapNotNull null
+            }
+
+            Pair(identifier, it)
+        }.toMap()
+
+        if (identifiers.isEmpty()) {
+            return null
+        }
+
+        val allPositioningData = mutableListOf<CellTowerPositioningData>()
+
+        try {
+            // just in case the potential additional requests fail, add only cached ones
+            allPositioningData.addAll(
+                cellService.getPositioningData(
+                    identifiers.keys.toList(),
+                    0
+                )
+            )
+
+            // don't make additional requests when we have 8 of the closest results with valid
+            // positioning data already
+            val onlyCachedThreshold = 8
+            val result =
+                cellService.getPositioningData(identifiers.keys.toList(), onlyCachedThreshold)
+            allPositioningData.clear()
+            allPositioningData.addAll(result)
+        } catch (e: IOException) {
+            Log.d(TAG, "unable to obtain positioning data: $e")
+            if (Log.isLoggable(TAG, Log.VERBOSE)) {
+                Log.v(TAG, "", e)
+            }
+        }
+
+        for (data in allPositioningData) {
+            val cellInfo = identifiers[data.identifier]
+            if (cellInfo != null && data.positioningData != null) {
+                bestResults[data.identifier] = PositionedCellInfo(cellInfo, data.positioningData)
+            }
+        }
+
+        if (bestResults.isEmpty()) {
+            return null
+        }
+
+        // use the median coordinates of nearby cells for protection against around 50%
+        // or less of them being in a wildly incorrect location
+        val refGeoPoint = GeoPoint(
+            bestResults.values.map { it.positioningData.latitude }.median() ?: return null,
+            bestResults.values.map { it.positioningData.longitude }.median() ?: return null,
+            bestResults.values.mapNotNull { it.positioningData.altitudeMeters }.let {
+                if (it.isNotEmpty()) it.average() else null
+            }
+        )
+
+        val measurements = bestResults.values.map { result ->
+            val positioningData = result.positioningData
+            // convert position to Cartesian coordinates
+            val position = geoPointToEnuPoint(
+                GeoPoint(
+                    positioningData.latitude,
+                    positioningData.longitude,
+                    positioningData.altitudeMeters?.toDouble()
+                ),
+                refGeoPoint
+            )
+            // the accuracyMeters for cell towers is the range of where the device could be located
+            // if it can see the tower
+            val xyPositionVariance = positioningData.accuracyMeters.toDouble().pow(2)
+            val zPositionVariance = positioningData.verticalAccuracyMeters?.toDouble()?.pow(2)
+            Measurement(
+                Position(
+                    Coordinate(
+                        true,
+                        position.x,
+                        xyPositionVariance,
+                    ),
+                    Coordinate(
+                        true,
+                        position.y,
+                        xyPositionVariance,
+                    ),
+                    Coordinate(
+                        position.z != null,
+                        position.z ?: 0.0,
+                        zPositionVariance ?: 0.0,
+                    ),
+                ),
+                // we can't estimate distance for cell towers
+                0.0,
+                0.0,
+            )
+        }
+
+        val time = SystemClock.elapsedRealtime()
+        val result = PositionEstimation.main(measurements.toTypedArray())
+        verboseLog(TAG) { "estimateLocationCell took ${(SystemClock.elapsedRealtime() - time)} ms" }
+        if (result == null) {
+            return null
+        }
+
+        val loc = Location(LocationManager.NETWORK_PROVIDER)
+
+        loc.elapsedRealtimeNanos =
+            bestResults.values.minOf { it.cellInfo.timestampMillis }.milliseconds.inWholeNanoseconds
         val locationAgeMillis =
             SystemClock.elapsedRealtime() - loc.elapsedRealtimeNanos / 1_000_000L
         loc.time = max(0L, System.currentTimeMillis() - locationAgeMillis)

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -1,4 +1,4 @@
-package app.grapheneos.networklocation.wifi
+package app.grapheneos.networklocation
 
 import android.location.Location
 import android.location.LocationManager
@@ -7,17 +7,18 @@ import android.location.provider.ProviderRequest
 import android.net.wifi.ScanResult
 import android.os.SystemClock
 import android.util.Log
-import app.grapheneos.networklocation.GeoPoint
-import app.grapheneos.networklocation.Point
-import app.grapheneos.networklocation.enuPointToGeoPoint
-import app.grapheneos.networklocation.geoPointToEnuPoint
 import app.grapheneos.networklocation.interop.position_estimation.Coordinate
 import app.grapheneos.networklocation.interop.position_estimation.Measurement
 import app.grapheneos.networklocation.interop.position_estimation.Position
 import app.grapheneos.networklocation.interop.position_estimation.PositionEstimation
-import app.grapheneos.networklocation.median
-import app.grapheneos.networklocation.rssiToDistance
-import app.grapheneos.networklocation.verboseLog
+import app.grapheneos.networklocation.wifi.Bssid
+import app.grapheneos.networklocation.wifi.PositioningData
+import app.grapheneos.networklocation.wifi.WifiApPositioningData
+import app.grapheneos.networklocation.wifi.WifiApRanger
+import app.grapheneos.networklocation.wifi.WifiApScanner
+import app.grapheneos.networklocation.wifi.WifiPositioningServiceCache
+import app.grapheneos.networklocation.wifi.WifiScanFailedException
+import app.grapheneos.networklocation.wifi.WifiScannerUnavailableException
 import java.io.IOException
 import kotlin.math.max
 import kotlin.math.pow

--- a/src/app/grapheneos/networklocation/PositionEstimation.kt
+++ b/src/app/grapheneos/networklocation/PositionEstimation.kt
@@ -43,9 +43,8 @@ fun List<Double>.median(): Double? {
  * the vicinity of the reference point. While this approximation works reasonably well for short
  * distances, its accuracy diminishes over longer distances due to Earth’s curvature.
  *
- * TODO: Consider using a more accurate implementation in the future, which may be needed when we
- *  support using cell towers as a data point for determining location because of how much further
- *  away from the user they may be compared to Wi-Fi networks.
+ * TODO: Consider using a more accurate implementation in the future, which may be crucial if we
+ *  ever locate using longer range technology than Wi-Fi and cellular.
  */
 fun geoPointToEnuPoint(geoPoint: GeoPoint, refGeoPoint: GeoPoint): Point {
     val dLat = Math.toRadians(geoPoint.latitude - refGeoPoint.latitude)

--- a/src/app/grapheneos/networklocation/PositioningData.kt
+++ b/src/app/grapheneos/networklocation/PositioningData.kt
@@ -1,0 +1,25 @@
+package app.grapheneos.networklocation
+
+class PositioningData(
+    val latitude: Double,
+    val longitude: Double,
+    val accuracyMeters: Int,
+    val altitudeMeters: Int?,
+    val verticalAccuracyMeters: Int?,
+) {
+    override fun toString(): String {
+        return StringBuilder().run {
+            append('{'); append(latitude); append(','); append(longitude)
+            append('±'); append(accuracyMeters); append('m')
+            if (altitudeMeters != null) {
+                append(" altitude:"); append(altitudeMeters)
+                if (verticalAccuracyMeters != null) {
+                    append('±'); append(verticalAccuracyMeters)
+                }
+                append('m')
+            }
+            append('}')
+            toString()
+        }
+    }
+}

--- a/src/app/grapheneos/networklocation/Throttle.kt
+++ b/src/app/grapheneos/networklocation/Throttle.kt
@@ -1,0 +1,17 @@
+package app.grapheneos.networklocation
+
+import android.os.SystemClock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+class Throttle(private val cooldown: Duration) {
+    private var lastTriggerElapsedRealtime = -cooldown
+
+    fun isThrottled() = elapsedRealtime() - lastTriggerElapsedRealtime < cooldown
+
+    private fun elapsedRealtime() = SystemClock.elapsedRealtime().milliseconds
+
+    fun trigger() {
+        lastTriggerElapsedRealtime = elapsedRealtime()
+    }
+}

--- a/src/app/grapheneos/networklocation/TimedLruCache.kt
+++ b/src/app/grapheneos/networklocation/TimedLruCache.kt
@@ -1,0 +1,70 @@
+package app.grapheneos.networklocation
+
+import android.annotation.ElapsedRealtimeLong
+import android.os.SystemClock
+import android.util.Log
+import android.util.LruCache
+import com.android.internal.annotations.GuardedBy
+import com.android.internal.os.BackgroundThread
+import java.util.Optional
+import kotlin.time.Duration
+
+private const val TAG = "TimedLruCache"
+
+class TimedLruCache<K, V>(maxSize: Int, private val cacheCleanupInterval: Duration) {
+    private val lruCache = LruCache<K, Entry<V>>(maxSize)
+
+    private class Entry<V>(val value: V) {
+        @ElapsedRealtimeLong
+        var lastAccessTime: Long = SystemClock.elapsedRealtime()
+            private set
+
+        @GuardedBy("TimedLruCache.lruCache")
+        fun updateLastAccessTime() {
+            lastAccessTime = SystemClock.elapsedRealtime()
+        }
+    }
+
+    fun checkCache(key: K): Optional<V>? {
+        val cacheEntry = synchronized {
+            val res = lruCache.get(key) ?: return@synchronized null
+            res.updateLastAccessTime()
+            res
+        } ?: return null
+        @Suppress("UNCHECKED_CAST")
+        return Optional.ofNullable<V>(cacheEntry.value) as Optional<V>
+    }
+
+    fun <R> synchronized(block: () -> R): R {
+        return synchronized(lruCache, block)
+    }
+
+    fun put(key: K, value: V) {
+        lruCache.put(key, Entry(value))
+    }
+
+    init {
+        scheduleClean()
+    }
+
+    private fun scheduleClean() {
+        // note that the time that the device spends in deep sleep is not counted against the delay
+        BackgroundThread.getHandler().postDelayed({ clean() }, cacheCleanupInterval.inWholeMilliseconds)
+    }
+
+    private fun clean() {
+        scheduleClean()
+        val minTime = SystemClock.elapsedRealtime() - cacheCleanupInterval.inWholeMilliseconds
+        var numRemoved = 0
+        synchronized {
+            lruCache.snapshot().entries.forEach {
+                if (it.value.lastAccessTime < minTime) {
+                    if (lruCache.remove(it.key) != null) {
+                        ++numRemoved
+                    }
+                }
+            }
+        }
+        Log.d(TAG, "clean() removed $numRemoved items")
+    }
+}

--- a/src/app/grapheneos/networklocation/cell/AppleCellPositioningService.kt
+++ b/src/app/grapheneos/networklocation/cell/AppleCellPositioningService.kt
@@ -1,0 +1,265 @@
+package app.grapheneos.networklocation.cell
+
+import android.util.Log
+import app.grapheneos.networklocation.ApplePositioningService
+import app.grapheneos.networklocation.PositioningData
+import app.grapheneos.networklocation.Throttle
+import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocation
+import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationRequest
+import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationResponse
+import app.grapheneos.networklocation.proto.AppleWpsProtos.GsmCellTower
+import app.grapheneos.networklocation.proto.AppleWpsProtos.LteCellTower
+import app.grapheneos.networklocation.proto.AppleWpsProtos.Nr5GCellTower
+import app.grapheneos.networklocation.proto.AppleWpsProtos.ScdmaCellTower
+import app.grapheneos.networklocation.verboseLog
+import java.io.IOException
+import kotlin.math.max
+import kotlin.time.Duration.Companion.seconds
+
+private const val TAG = "AppleCps"
+private const val EXTRA_VERBOSE_TAG = "AppleCpsVV"
+
+private const val MAX_REQUEST_TOWERS = 12
+private const val THROTTLED_ADDITIONAL_RESULTS = 4
+private const val MAX_ADDITIONAL_RESULTS = 25
+private const val THROTTLE_TRIGGER_RESULT_COUNT = 10
+
+class AppleCellPositioningService : CellPositioningService {
+    private val applePs = ApplePositioningService()
+
+    private var throttle = Throttle(10.seconds)
+
+    @Throws(IOException::class)
+    override fun fetchNearbyTowerPositioningData(identifiers: List<Identifier>): List<CellTowerPositioningData> {
+        val requestIdentifiers = identifiers.take(MAX_REQUEST_TOWERS)
+        val result = HashMap<Identifier, PositioningData?>()
+
+        val response = fetchInner(
+            requestIdentifiers, if (throttle.isThrottled()) {
+                THROTTLED_ADDITIONAL_RESULTS
+            } else {
+                MAX_ADDITIONAL_RESULTS
+            }
+        )
+
+        val fullTowerCount =
+            response.nr5GCellTowersCount + response.lteCellTowersCount + response.scdmaCellTowersCount + response.gsmCellTowersCount
+        if (fullTowerCount >= THROTTLE_TRIGGER_RESULT_COUNT) {
+            verboseLog(TAG) { "response tower count ($fullTowerCount) triggered throttle" }
+            throttle.trigger()
+        }
+
+        for (tower in response.nr5GCellTowersList) {
+            result.putIfAbsent(
+                Identifier(
+                    standard = Standard.NR,
+                    mcc = tower.mcc,
+                    mnc = tower.mnc,
+                    lac = tower.tacId,
+                    cellId = tower.cellId,
+                ),
+                convertPositioningData(tower.location)
+            )
+        }
+        for (tower in response.lteCellTowersList) {
+            result.putIfAbsent(
+                Identifier(
+                    standard = Standard.LTE,
+                    mcc = tower.mcc,
+                    mnc = tower.mnc,
+                    lac = tower.tacId,
+                    cellId = tower.cellId.toLong(),
+                ),
+                convertPositioningData(tower.location)
+            )
+        }
+        for (tower in response.scdmaCellTowersList) {
+            result.putIfAbsent(
+                Identifier(
+                    standard = Standard.WCDMA,
+                    mcc = tower.mcc,
+                    mnc = tower.mnc,
+                    lac = tower.lacId,
+                    cellId = tower.cellId.toLong(),
+                ),
+                convertPositioningData(tower.location)
+            )
+        }
+        for (tower in response.gsmCellTowersList) {
+            result.putIfAbsent(
+                Identifier(
+                    standard = Standard.GSM,
+                    mcc = tower.mcc,
+                    mnc = tower.mnc,
+                    lac = tower.lacId,
+                    cellId = tower.cellId.toLong(),
+                ),
+                convertPositioningData(tower.location)
+            )
+        }
+        for (identifier in requestIdentifiers) {
+            result.putIfAbsent(identifier, null)
+        }
+
+        return result.map { CellTowerPositioningData(it.key, it.value) }
+    }
+
+    @Throws(IOException::class)
+    private fun fetchInner(
+        identifiers: List<Identifier>, maxAdditionalResults: Int
+    ): ALSLocationResponse {
+        verboseLog(TAG) { "request identifiers: $identifiers" }
+
+        val request = ALSLocationRequest.newBuilder().run {
+            for (id in identifiers) {
+                when (id.standard) {
+                    Standard.NR -> addNr5GCellTowers(
+                        Nr5GCellTower.newBuilder()
+                            .setMcc(id.mcc)
+                            .setMnc(id.mnc)
+                            .setTacId(id.lac)
+                            .setCellId(id.cellId)
+                            .build()
+                    )
+
+                    Standard.LTE -> addLteCellTowers(
+                        LteCellTower.newBuilder()
+                            .setMcc(id.mcc)
+                            .setMnc(id.mnc)
+                            .setTacId(id.lac)
+                            .setCellId(id.cellId.toInt())
+                            .build()
+                    )
+
+                    Standard.WCDMA -> addScdmaCellTowers(
+                        ScdmaCellTower.newBuilder()
+                            .setMcc(id.mcc)
+                            .setMnc(id.mnc)
+                            .setLacId(id.lac)
+                            .setCellId(id.cellId.toInt())
+                            .build()
+                    )
+
+                    Standard.GSM -> addGsmCellTowers(
+                        GsmCellTower.newBuilder()
+                            .setMcc(id.mcc)
+                            .setMnc(id.mnc)
+                            .setLacId(id.lac)
+                            .setCellId(id.cellId.toInt())
+                            .build()
+                    )
+                }
+            }
+
+            // Apple's service returns more additional results than we request
+            val baselineMaxAdditionalResults = 19
+            val adjustedMaxAdditionalResults = if (maxAdditionalResults > baselineMaxAdditionalResults) {
+                maxAdditionalResults - baselineMaxAdditionalResults
+            } else if (maxAdditionalResults == 0) {
+                0
+            } else {
+                1
+            }
+
+            val totalRequestedTowersCount =
+                nr5GCellTowersCount + lteCellTowersCount + scdmaCellTowersCount + gsmCellTowersCount
+
+            // should be at least 1 for each standard of towers we request, otherwise it defaults to
+            // around 120
+            if (nr5GCellTowersCount != 0) {
+                setNumberOfSurroundingNr5GCells(
+                    max(
+                        1,
+                        (adjustedMaxAdditionalResults * (nr5GCellTowersCount.toDouble() /
+                                totalRequestedTowersCount.toDouble())).toInt()
+                    )
+                )
+            }
+            if (lteCellTowersCount != 0) {
+                setNumberOfSurroundingLteCells(
+                    max(
+                        1,
+                        (adjustedMaxAdditionalResults * (lteCellTowersCount.toDouble() /
+                                totalRequestedTowersCount.toDouble())).toInt()
+                    )
+                )
+            }
+            if (scdmaCellTowersCount != 0) {
+                setNumberOfSurroundingScdmaCells(
+                    max(
+                        1,
+                        (adjustedMaxAdditionalResults * (scdmaCellTowersCount.toDouble() /
+                                totalRequestedTowersCount.toDouble())).toInt()
+                    )
+                )
+            }
+            if (gsmCellTowersCount != 0) {
+                setNumberOfSurroundingGsmCells(
+                    max(
+                        1,
+                        (adjustedMaxAdditionalResults * (gsmCellTowersCount.toDouble() /
+                                totalRequestedTowersCount.toDouble())).toInt()
+                    )
+                )
+            }
+
+            setMeta(applePs.macosMeta)
+
+            build()
+        }
+
+        val response = applePs.fetch(request)
+        verboseLog(TAG) {
+            "response tower list size: ${
+                response.nr5GCellTowersCount + response.lteCellTowersCount +
+                        response.scdmaCellTowersCount + response.gsmCellTowersCount
+            }"
+        }
+        if (Log.isLoggable(EXTRA_VERBOSE_TAG, Log.VERBOSE)) {
+            response.nr5GCellTowersList.forEachIndexed { i, tower ->
+                Log.v(
+                    EXTRA_VERBOSE_TAG, "NR response[$i]: cell ID: ${tower.cellId}, " +
+                            "positioning data: ${convertPositioningData(tower.location)}"
+                )
+            }
+            response.lteCellTowersList.forEachIndexed { i, tower ->
+                Log.v(
+                    EXTRA_VERBOSE_TAG, "LTE response[$i]: cell ID: ${tower.cellId}, " +
+                            "positioning data: ${convertPositioningData(tower.location)}"
+                )
+            }
+            response.scdmaCellTowersList.forEachIndexed { i, tower ->
+                Log.v(
+                    EXTRA_VERBOSE_TAG, "(S/W)CDMA response[$i]: cell ID: ${tower.cellId}, " +
+                            "positioning data: ${convertPositioningData(tower.location)}"
+                )
+            }
+            response.gsmCellTowersList.forEachIndexed { i, tower ->
+                Log.v(
+                    EXTRA_VERBOSE_TAG, "GSM response[$i]: cell ID: ${tower.cellId}, " +
+                            "positioning data: ${convertPositioningData(tower.location)}"
+                )
+            }
+        }
+        return response
+    }
+
+    private fun convertPositioningData(pd: ALSLocation): PositioningData? {
+        if (pd.latitude == -18000000000) {
+            return null
+        }
+        val latitude = pd.latitude * 0.000_000_01
+        val longitude = pd.longitude * 0.000_000_01
+        // the API doesn't seem to return an altitude for cell towers (always returns 0), so we
+        // just set it to null
+        val altitudeMeters = null
+        val verticalAccuracyMeters = null
+        return PositioningData(
+            latitude,
+            longitude,
+            pd.accuracy,
+            altitudeMeters,
+            verticalAccuracyMeters
+        )
+    }
+}

--- a/src/app/grapheneos/networklocation/cell/CellPositioningService.kt
+++ b/src/app/grapheneos/networklocation/cell/CellPositioningService.kt
@@ -1,0 +1,34 @@
+package app.grapheneos.networklocation.cell
+
+import app.grapheneos.networklocation.PositioningData
+import java.io.IOException
+
+interface CellPositioningService {
+    @Throws(IOException::class)
+    fun fetchNearbyTowerPositioningData(identifiers: List<Identifier>): List<CellTowerPositioningData>
+}
+
+enum class Standard {
+    NR,
+    LTE,
+    WCDMA,
+    GSM,
+}
+
+data class Identifier(
+    val standard: Standard,
+    val mcc: Int,
+    val mnc: Int,
+    val lac: Int,
+    val cellId: Long,
+)
+
+class CellTowerPositioningData(
+    val identifier: Identifier,
+    val positioningData: PositioningData?,
+) {
+    override fun toString(): String {
+        val pd = positioningData
+        return if (pd == null) "$identifier (no positioning data)" else "${identifier}_$pd"
+    }
+}

--- a/src/app/grapheneos/networklocation/cell/CellPositioningServiceCache.kt
+++ b/src/app/grapheneos/networklocation/cell/CellPositioningServiceCache.kt
@@ -1,0 +1,68 @@
+package app.grapheneos.networklocation.cell
+
+import android.util.Log
+import app.grapheneos.networklocation.TimedLruCache
+import java.io.IOException
+import kotlin.time.Duration.Companion.minutes
+
+private const val TAG = "CellPositioningServiceCache"
+
+class CellPositioningServiceCache(private val service: CellPositioningService) {
+    private val timedLruCache =
+        TimedLruCache<Identifier, CellTowerPositioningData>(1_000, 15.minutes)
+
+    @Throws(IOException::class)
+    fun getPositioningData(
+        identifiers: List<Identifier>,
+        onlyCachedThreshold: Int,
+    ): List<CellTowerPositioningData> {
+        val isVerbose = Log.isLoggable(TAG, Log.VERBOSE)
+        val positioningData = mutableListOf<CellTowerPositioningData>()
+        val queryIdentifiers = mutableListOf<Identifier>()
+
+        for (identifier in identifiers) {
+            val cacheEntry = timedLruCache.checkCache(identifier)
+            if (cacheEntry != null) {
+                val res = cacheEntry.orElse(null).positioningData
+                if (isVerbose) Log.v(
+                    TAG,
+                    "getPositioningData: cache hit for $identifier: $res"
+                )
+                if (res != null) {
+                    positioningData.add(CellTowerPositioningData(identifier, res))
+                }
+            } else if (positioningData.size < onlyCachedThreshold || queryIdentifiers.isNotEmpty()) {
+                queryIdentifiers.add(identifier)
+            }
+        }
+
+        if (queryIdentifiers.isEmpty()) {
+            return positioningData
+        }
+
+        if (isVerbose) Log.v(TAG, "querying positioning data for $queryIdentifiers")
+        val towerInfos: List<CellTowerPositioningData> =
+            service.fetchNearbyTowerPositioningData(queryIdentifiers)
+        if (isVerbose) Log.v(TAG, "service response: $towerInfos")
+
+        timedLruCache.synchronized {
+            for (pd in towerInfos) {
+                timedLruCache.put(pd.identifier, pd)
+            }
+            for ((index, identifier) in queryIdentifiers.withIndex()) {
+                val cacheEntry = timedLruCache.checkCache(identifier)
+                if (cacheEntry != null) {
+                    val res = cacheEntry.orElse(null).positioningData
+                    res?.let { positioningData.add(CellTowerPositioningData(identifier, it)) }
+                } else if (index <= onlyCachedThreshold) {
+                    Log.w(
+                        TAG,
+                        "cache lookup for $identifier failed after service.fetchNearbyTowerPositioningData()"
+                    )
+                }
+            }
+        }
+
+        return positioningData
+    }
+}

--- a/src/app/grapheneos/networklocation/cell/CellTowerScanner.kt
+++ b/src/app/grapheneos/networklocation/cell/CellTowerScanner.kt
@@ -1,0 +1,73 @@
+package app.grapheneos.networklocation.cell
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.WorkSource
+import android.telephony.CellInfo
+import android.telephony.TelephonyManager
+import app.grapheneos.networklocation.verboseLog
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.jvm.Throws
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+private const val TAG = "CellTowerScanner"
+
+class CellTowerScanner(private val context: Context) {
+    private val scanExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+
+    @Throws(CellScannerUnavailableException::class, CellScanFailedException::class)
+    suspend fun scan(workSource: WorkSource): List<CellInfo> {
+        if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
+            throw CellScannerUnavailableException("device does not support FEATURE_TELEPHONY")
+        }
+
+        val telephonyManager = context.getSystemService(TelephonyManager::class.java)
+            ?: throw CellScannerUnavailableException("telephonyManager is null")
+
+        if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY_RADIO_ACCESS)) {
+            if (telephonyManager.radioPowerState != TelephonyManager.RADIO_POWER_ON) {
+                throw CellScannerUnavailableException("cellular radio power isn't on")
+            }
+        } else {
+            throw CellScannerUnavailableException("device does not support FEATURE_TELEPHONY_RADIO_ACCESS")
+        }
+
+        return suspendCancellableCoroutine { continuation ->
+            val callback = object : TelephonyManager.CellInfoCallback() {
+                override fun onCellInfo(cellInfo: MutableList<CellInfo>) {
+                    verboseLog(TAG) { "onCellInfo: size: ${cellInfo.size}" }
+                    continuation.resume(cellInfo)
+                }
+
+                override fun onError(errorCode: Int, detail: Throwable?) {
+                    verboseLog(TAG) { "onError: errorCode: $errorCode, detail: $detail" }
+                    continuation.resumeWithException(CellScanFailedException(errorCode, detail))
+                }
+            }
+            verboseLog(TAG) { "calling requestCellInfoUpdate" }
+            telephonyManager.requestCellInfoUpdate(
+                workSource,
+                scanExecutor,
+                callback,
+            )
+            continuation.invokeOnCancellation {
+                verboseLog(TAG) { "cancelling scan" }
+                scanExecutor.shutdownNow()
+                verboseLog(TAG) { "maybe cancelled scan" }
+            }
+        }
+    }
+}
+
+class CellScannerUnavailableException(msg: String) : Exception(msg) {
+    override fun toString() = "CellScannerUnavailableException: $message"
+}
+
+class CellScanFailedException(private val errorCode: Int, private val detail: Throwable?) : Exception() {
+    override fun toString(): String {
+        return "CellScanFailedException{errorCode: $errorCode, detail: $detail}"
+    }
+}

--- a/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
+++ b/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
@@ -1,6 +1,5 @@
 package app.grapheneos.networklocation.wifi
 
-import android.os.SystemClock
 import android.util.Log
 import app.grapheneos.networklocation.ApplePositioningService
 import app.grapheneos.networklocation.Throttle
@@ -11,7 +10,6 @@ import app.grapheneos.networklocation.proto.AppleWpsProtos.WirelessAP
 import app.grapheneos.networklocation.verboseLog
 import java.io.IOException
 import kotlin.math.max
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "AppleWps"
@@ -20,13 +18,12 @@ private const val EXTRA_VERBOSE_TAG = "AppleWpsVV"
 private const val MAX_REQUEST_NETWORKS = 40
 private const val THROTTLED_ADDITIONAL_RESULTS = 8
 private const val MAX_ADDITIONAL_RESULTS = 100
-private val THROTTLE_COOLDOWN = 10.seconds
 private const val THROTTLE_TRIGGER_RESULT_COUNT = 17
 
 class AppleWifiPositioningService : WifiPositioningService {
     private val applePs = ApplePositioningService()
 
-    private var throttleTriggeredElapsedRealtime = -THROTTLE_COOLDOWN
+    private var throttle = Throttle(10.seconds)
 
     @Throws(IOException::class)
     override fun fetchNearbyApPositioningData(bssids: List<String>): List<WifiApPositioningData> {
@@ -35,16 +32,16 @@ class AppleWifiPositioningService : WifiPositioningService {
 
         val response = fetchInner(
             requestBssids,
-            if (SystemClock.elapsedRealtime().milliseconds - throttleTriggeredElapsedRealtime >= THROTTLE_COOLDOWN) {
-                MAX_ADDITIONAL_RESULTS
-            } else {
+            if (throttle.isThrottled()) {
                 THROTTLED_ADDITIONAL_RESULTS
+            } else {
+                MAX_ADDITIONAL_RESULTS
             }
         )
 
         if (response.wirelessApsCount >= THROTTLE_TRIGGER_RESULT_COUNT) {
             verboseLog(TAG) { "response AP count (${response.wirelessApsCount}) triggered throttle" }
-            throttleTriggeredElapsedRealtime = SystemClock.elapsedRealtime().milliseconds
+            throttle.trigger()
         }
 
         for (ap in response.wirelessApsList) {

--- a/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
+++ b/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
@@ -1,28 +1,18 @@
 package app.grapheneos.networklocation.wifi
 
-import android.app.AppGlobals
-import android.content.Context
-import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_DISABLED
-import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SERVER_APPLE
-import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SERVER_GRAPHENEOS_PROXY
-import android.ext.settings.NetworkLocationSettings.NETWORK_LOCATION_SETTING
 import android.os.SystemClock
 import android.util.Log
+import app.grapheneos.networklocation.ApplePositioningService
+import app.grapheneos.networklocation.Throttle
 import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocation
 import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationRequest
 import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationResponse
-import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationRequest.ALSMeta
 import app.grapheneos.networklocation.proto.AppleWpsProtos.WirelessAP
 import app.grapheneos.networklocation.verboseLog
-import java.io.DataOutputStream
 import java.io.IOException
-import java.net.HttpURLConnection
-import java.net.URL
-import javax.net.ssl.HttpsURLConnection
 import kotlin.math.max
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import org.grapheneos.tls.ModernTLSSocketFactory
 
 private const val TAG = "AppleWps"
 private const val EXTRA_VERBOSE_TAG = "AppleWpsVV"
@@ -34,8 +24,7 @@ private val THROTTLE_COOLDOWN = 10.seconds
 private const val THROTTLE_TRIGGER_RESULT_COUNT = 17
 
 class AppleWifiPositioningService : WifiPositioningService {
-
-    private val tlsSocketFactory = ModernTLSSocketFactory()
+    private val applePs = ApplePositioningService()
 
     private var throttleTriggeredElapsedRealtime = -THROTTLE_COOLDOWN
 
@@ -75,92 +64,40 @@ class AppleWifiPositioningService : WifiPositioningService {
 
     @Throws(IOException::class)
     private fun fetchInner(bssids: List<Bssid>, maxAdditionalResults: Int): ALSLocationResponse {
-        val (url, enforceModernTls) = getServerUrl()
-
         verboseLog(TAG) {"request bssids: $bssids"}
 
-        val connection = url.openConnection() as HttpsURLConnection
-        try {
-            if (enforceModernTls) {
-                connection.sslSocketFactory = tlsSocketFactory
-            }
-            connection.requestMethod = "POST"
-            connection.setRequestProperty("Accept", "*/*")
-            connection.setRequestProperty("Accept-Language", "en-US,en;q=0.9")
-            connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded")
-            connection.setRequestProperty("User-Agent", "locationd/2960.0.57 CFNetwork/3826.500.111.1.1 Darwin/24.4.0")
-            connection.connectTimeout = 10_000
-            connection.readTimeout = 10_000
-            connection.doOutput = true
+        val request = ALSLocationRequest.newBuilder().run {
+            addAllWirelessAps(bssids.map {
+                WirelessAP.newBuilder()
+                    .setMacId(it)
+                    .build()
+            })
+            // should be at least 1, otherwise it defaults to around 400
+            setNumberOfSurroundingWifis(max(1, maxAdditionalResults))
+            val wifiBands = listOf(
+                ALSLocationRequest.WifiBand.K2DOT4GHZ,
+                ALSLocationRequest.WifiBand.K5GHZ,
+            )
+            addAllSurroundingWifiBands(wifiBands)
+            setWifiAltitudeScale(ALSLocationRequest.WifiAltitudeScale.KWIFI_ALTITUDE_SCALE_10_TO_THE_2)
+            setMeta(applePs.macosMeta)
 
-            DataOutputStream(connection.outputStream).use { outputStream ->
-                val locale = "en-US_US".toByteArray()
-                val identifier = "com.apple.locationd".toByteArray()
-                val version = "15.4.24E248".toByteArray()
-                val requestCode = 1
-
-                outputStream.writeShort(1) // hardcoded
-                outputStream.writeShort(locale.size)
-                outputStream.write(locale)
-                outputStream.writeShort(identifier.size)
-                outputStream.write(identifier)
-                outputStream.writeShort(version.size)
-                outputStream.write(version)
-                outputStream.writeInt(requestCode)
-
-                val protobufData = ALSLocationRequest.newBuilder().run {
-                    addAllWirelessAps(bssids.map {
-                        WirelessAP.newBuilder()
-                            .setMacId(it)
-                            .build()
-                    })
-                    // should be at least 1, otherwise it defaults to around 400
-                    setNumberOfSurroundingWifis(max(1, maxAdditionalResults))
-                    val wifiBands = listOf(
-                        ALSLocationRequest.WifiBand.K2DOT4GHZ,
-                        ALSLocationRequest.WifiBand.K5GHZ,
-                    )
-                    addAllSurroundingWifiBands(wifiBands)
-                    setWifiAltitudeScale(ALSLocationRequest.WifiAltitudeScale.KWIFI_ALTITUDE_SCALE_10_TO_THE_2)
-                    setMeta(
-                        ALSMeta.newBuilder()
-                            .setSoftwareBuild("macOS15.4/24E248")
-                            .setProductId("arm64")
-                            .build()
-                    )
-
-                    build()
-                }
-
-                outputStream.writeInt(protobufData.getSerializedSize())
-                protobufData.writeTo(outputStream)
-            }
-
-            val responseCode = connection.responseCode
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw IOException("non-200 response code: $responseCode")
-            }
-            val ignoredHeaderSize = 10
-            val protoBytes: ByteArray = connection.inputStream.use { inputStream ->
-                inputStream.skipNBytes(ignoredHeaderSize.toLong())
-                inputStream.readAllBytes()
-            }
-            val response = ALSLocationResponse.parseFrom(protoBytes)
-            verboseLog(TAG) {
-                "response AP list size: ${response.wirelessApsCount}, " +
-                        "byte size: ${protoBytes.size + ignoredHeaderSize}"
-            }
-            if (Log.isLoggable(EXTRA_VERBOSE_TAG, Log.VERBOSE)) {
-                Log.v(EXTRA_VERBOSE_TAG, "response headers: " + connection.headerFields)
-                response.wirelessApsList.forEachIndexed { i, ap ->
-                    Log.v(EXTRA_VERBOSE_TAG, "response[$i]: bssid: ${ap.macId}, " +
-                            "positioning data: ${convertPositioningData(ap.location)}")
-                }
-            }
-            return response
-        } finally {
-            connection.disconnect()
+            build()
         }
+
+        val response = applePs.fetch(request)
+        verboseLog(TAG) {
+            "response AP list size: ${response.wirelessApsCount}"
+        }
+        if (Log.isLoggable(EXTRA_VERBOSE_TAG, Log.VERBOSE)) {
+            response.wirelessApsList.forEachIndexed { i, ap ->
+                Log.v(
+                    EXTRA_VERBOSE_TAG, "response[$i]: bssid: ${ap.macId}, " +
+                            "positioning data: ${convertPositioningData(ap.location)}"
+                )
+            }
+        }
+        return response
     }
 
     private fun convertPositioningData(pd: ALSLocation): PositioningData? {
@@ -178,23 +115,6 @@ class AppleWifiPositioningService : WifiPositioningService {
             if (it == -100 || altitudeMeters == null) null else it / 100
         }
         return PositioningData(latitude, longitude, pd.accuracy, altitudeMeters, verticalAccuracyMeters)
-    }
-
-    @Throws(IOException::class)
-    private fun getServerUrl(): Pair<URL, Boolean> {
-        val context: Context = AppGlobals.getInitialApplication()
-        val setting = NETWORK_LOCATION_SETTING.get(context)
-        return when (setting) {
-            NETWORK_LOCATION_SERVER_GRAPHENEOS_PROXY ->
-                Pair(URL("https://gs-loc.apple.grapheneos.org/clls/wloc"), true)
-            NETWORK_LOCATION_SERVER_APPLE ->
-                Pair(URL("https://gs-loc.apple.com/clls/wloc"), false)
-            NETWORK_LOCATION_DISABLED ->
-                // network location can be disabled by the user at any point
-                throw IOException("network location setting became disabled")
-            else ->
-                throw IllegalStateException("unexpected URL setting: $setting")
-        }
     }
 }
 

--- a/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
+++ b/src/app/grapheneos/networklocation/wifi/AppleWifiPositioningService.kt
@@ -2,6 +2,7 @@ package app.grapheneos.networklocation.wifi
 
 import android.util.Log
 import app.grapheneos.networklocation.ApplePositioningService
+import app.grapheneos.networklocation.PositioningData
 import app.grapheneos.networklocation.Throttle
 import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocation
 import app.grapheneos.networklocation.proto.AppleWpsProtos.ALSLocationRequest

--- a/src/app/grapheneos/networklocation/wifi/WifiPositioningService.kt
+++ b/src/app/grapheneos/networklocation/wifi/WifiPositioningService.kt
@@ -1,5 +1,6 @@
 package app.grapheneos.networklocation.wifi
 
+import app.grapheneos.networklocation.PositioningData
 import java.io.IOException
 
 interface WifiPositioningService {
@@ -14,29 +15,5 @@ class WifiApPositioningData(
     override fun toString(): String {
         val pd = positioningData
         return if (pd == null) "$bssid (no positioning data)" else "${bssid}_$pd"
-    }
-}
-
-class PositioningData(
-    val latitude: Double,
-    val longitude: Double,
-    val accuracyMeters: Int,
-    val altitudeMeters: Int?,
-    val verticalAccuracyMeters: Int?,
-) {
-    override fun toString(): String {
-        return StringBuilder().run {
-            append('{'); append(latitude); append(','); append(longitude)
-            append('±'); append(accuracyMeters); append('m')
-            if (altitudeMeters != null) {
-                append(" altitude:"); append(altitudeMeters)
-                if (verticalAccuracyMeters != null) {
-                    append('±'); append(verticalAccuracyMeters)
-                }
-                append('m')
-            }
-            append('}')
-            toString()
-        }
     }
 }

--- a/src/app/grapheneos/networklocation/wifi/WifiPositioningServiceCache.kt
+++ b/src/app/grapheneos/networklocation/wifi/WifiPositioningServiceCache.kt
@@ -1,34 +1,16 @@
 package app.grapheneos.networklocation.wifi
 
-import android.annotation.ElapsedRealtimeLong
-import android.os.SystemClock
 import android.util.Log
-import android.util.LruCache
-import app.grapheneos.networklocation.PositioningData
-import com.android.internal.annotations.GuardedBy
-import com.android.internal.os.BackgroundThread
+import app.grapheneos.networklocation.TimedLruCache
 import java.io.IOException
-import java.util.Optional
+import kotlin.time.Duration.Companion.minutes
 
 private const val TAG = "WifiPositioningServiceCache"
 
 typealias Bssid = String
 
-private const val CACHE_CAPACITY = 10_000
-private const val CACHE_CLEANUP_INTERVAL_MILLIS: Long = 15 * 60_000L // 15 minutes
-
 class WifiPositioningServiceCache(private val service: WifiPositioningService) {
-    private val lruCache = LruCache<Bssid, Entry>(CACHE_CAPACITY)
-
-    private class Entry(val apPositioningData: WifiApPositioningData) {
-        @ElapsedRealtimeLong var lastAccessTime: Long = SystemClock.elapsedRealtime()
-            private set
-
-        @GuardedBy("WifiPositioningServiceCache.lruCache")
-        fun updateLastAccessTime() {
-            lastAccessTime = SystemClock.elapsedRealtime()
-        }
-    }
+    private val timedLruCache = TimedLruCache<Bssid, WifiApPositioningData>(10_000, 15.minutes)
 
     @Throws(IOException::class)
     fun getPositioningData(
@@ -40,9 +22,9 @@ class WifiPositioningServiceCache(private val service: WifiPositioningService) {
         val queryBssids = mutableListOf<Bssid>()
 
         for (bssid in bssids) {
-            val cacheEntry = checkCache(bssid)
+            val cacheEntry = timedLruCache.checkCache(bssid)
             if (cacheEntry != null) {
-                val res = cacheEntry.orElse(null)
+                val res = cacheEntry.orElse(null).positioningData
                 if (isVerbose) Log.v(
                     TAG,
                     "getPositioningData: cache hit for $bssid: $res"
@@ -64,14 +46,14 @@ class WifiPositioningServiceCache(private val service: WifiPositioningService) {
             service.fetchNearbyApPositioningData(queryBssids)
         if (isVerbose) Log.v(TAG, "service response: $apInfos")
 
-        synchronized(lruCache) {
+        timedLruCache.synchronized {
             for (pd in apInfos) {
-                lruCache.put(pd.bssid, Entry(pd))
+                timedLruCache.put(pd.bssid, pd)
             }
             for ((index, bssid) in queryBssids.withIndex()) {
-                val cacheEntry = checkCache(bssid)
+                val cacheEntry = timedLruCache.checkCache(bssid)
                 if (cacheEntry != null) {
-                    val res = cacheEntry.orElse(null)
+                    val res = cacheEntry.orElse(null).positioningData
                     res?.let { positioningData.add(WifiApPositioningData(bssid, it)) }
                 } else if (index <= onlyCachedThreshold) {
                     Log.w(
@@ -83,39 +65,5 @@ class WifiPositioningServiceCache(private val service: WifiPositioningService) {
         }
 
         return positioningData
-    }
-
-    private fun checkCache(bssid: Bssid): Optional<PositioningData>? {
-        val cacheEntry = synchronized(lruCache) {
-            val res = lruCache.get(bssid) ?: return null
-            res.updateLastAccessTime()
-            res
-        }
-        return Optional.ofNullable(cacheEntry.apPositioningData.positioningData)
-    }
-
-    init {
-        scheduleClean()
-    }
-
-    private fun scheduleClean() {
-        // note that the time that the device spends in deep sleep is not counted against the delay
-        BackgroundThread.getHandler().postDelayed({ clean() }, CACHE_CLEANUP_INTERVAL_MILLIS)
-    }
-
-    private fun clean() {
-        scheduleClean()
-        val minTime = SystemClock.elapsedRealtime() - CACHE_CLEANUP_INTERVAL_MILLIS
-        var numRemoved = 0
-        synchronized(lruCache) {
-            lruCache.snapshot().entries.forEach {
-                if (it.value.lastAccessTime < minTime) {
-                    if (lruCache.remove(it.key) != null) {
-                        ++numRemoved
-                    }
-                }
-            }
-        }
-        Log.d(TAG, "clean() removed $numRemoved items")
     }
 }

--- a/src/app/grapheneos/networklocation/wifi/WifiPositioningServiceCache.kt
+++ b/src/app/grapheneos/networklocation/wifi/WifiPositioningServiceCache.kt
@@ -4,6 +4,7 @@ import android.annotation.ElapsedRealtimeLong
 import android.os.SystemClock
 import android.util.Log
 import android.util.LruCache
+import app.grapheneos.networklocation.PositioningData
 import com.android.internal.annotations.GuardedBy
 import com.android.internal.os.BackgroundThread
 import java.io.IOException


### PR DESCRIPTION
Cell-based location used as a fallback for when Wi-Fi-based location fails. Supports NR (5G), LTE (4G), WCDMA (3G), and GSM (2G).

WCDMA support is untested.

Part of a changelist:
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/368