### PR TITLE
set custom user agent for geocoder

### DIFF
--- a/src/app/grapheneos/geocoder/NominatimGeocoder.kt
+++ b/src/app/grapheneos/geocoder/NominatimGeocoder.kt
@@ -24,6 +24,9 @@ import org.grapheneos.tls.ModernTLSSocketFactory
 private const val TAG = "NominatimGeocoder"
 private const val EXTRA_VERBOSE_TAG = "NominatimGeocoderVV"
 
+/** Version which should get incremented when request behavior changes */
+private const val USER_AGENT_VERSION = 1
+
 class NominatimGeocoder : Geocoder {
     private val tlsSocketFactory = ModernTLSSocketFactory()
 
@@ -83,6 +86,10 @@ class NominatimGeocoder : Geocoder {
             }
             connection.requestMethod = "GET"
             connection.setRequestProperty("Accept-Language", preferredLocale.toLanguageTag())
+            connection.setRequestProperty(
+                "User-Agent",
+                "GrapheneOS geocoder $USER_AGENT_VERSION"
+            )
             connection.connectTimeout = 10_000
             connection.readTimeout = 10_000
 


### PR DESCRIPTION
Nominatim's official server usage policy states that a custom user agent is required. 

It has been set to `GrapheneOS geocoder $USER_AGENT_VERSION`, where `$USER_AGENT_VERSION` is a constant that should get incremented when request behavior changes.