### PR TITLE
Some more position estimation improvements and improve WIP Wi-Fi RTT support

### DIFF
--- a/interop/position-estimation_kotlin/src/app/grapheneos/networklocation/interop/position_estimation/Measurement.kt
+++ b/interop/position-estimation_kotlin/src/app/grapheneos/networklocation/interop/position_estimation/Measurement.kt
@@ -3,5 +3,5 @@ package app.grapheneos.networklocation.interop.position_estimation
 data class Measurement(
     var position: Position,
     var distance: Double,
-    var probability: Double,
+    var weight: Double,
 )

--- a/interop/position-estimation_rust/src/jni.rs
+++ b/interop/position-estimation_rust/src/jni.rs
@@ -77,9 +77,9 @@ pub extern "system" fn Java_app_grapheneos_networklocation_interop_position_1est
     let measurement_distance_field_id = env
         .get_field_id(measurement_class_path, "distance", "D")
         .expect("should be able to get measurement class' distance field id");
-    let measurement_probability_field_id = env
-        .get_field_id(measurement_class_path, "probability", "D")
-        .expect("should be able to get measurement class' probability field id");
+    let measurement_weight_field_id = env
+        .get_field_id(measurement_class_path, "weight", "D")
+        .expect("should be able to get measurement class' weight field id");
 
     for index in 0..len {
         let measurement_obj = env
@@ -244,15 +244,15 @@ pub extern "system" fn Java_app_grapheneos_networklocation_interop_position_1est
                 .expect("should be able to get distance from measurement")
                 .d()
                 .expect("distance should be a double"),
-            probability: env
+            weight: env
                 .get_field_unchecked(
                     &measurement_obj,
-                    measurement_probability_field_id,
+                    measurement_weight_field_id,
                     jni::signature::ReturnType::Primitive(jni::signature::Primitive::Double),
                 )
-                .expect("should be able to get probability from measurement")
+                .expect("should be able to get weight from measurement")
                 .d()
-                .expect("probability should be a double"),
+                .expect("weight should be a double"),
         };
 
         debug!(

--- a/interop/position-estimation_rust/src/lib.rs
+++ b/interop/position-estimation_rust/src/lib.rs
@@ -50,19 +50,21 @@ pub fn estimate_position(measurements: &[Measurement]) -> Option<EstimatedPositi
     measurements_indices = measurements_indices
         .iter()
         .sorted_by(|m1, m2| {
-            measurements[**m1]
-                .distance
-                .total_cmp(&measurements[**m2].distance)
+            let m1 = measurements[**m1];
+            let m1_standard_deviation =
+                (m1.position.x.variance + m1.position.y.variance + m1.position.z.variance).sqrt();
+            let m2 = measurements[**m2];
+            let m2_standard_deviation =
+                (m2.position.x.variance + m2.position.y.variance + m2.position.z.variance).sqrt();
+
+            m1_standard_deviation.total_cmp(&m2_standard_deviation)
         })
         .take(max_measurements_for_combos)
         .cloned()
         .collect();
-    let top_closest_measurements_indices = &measurements_indices[0..max_measurements_for_combos];
+    let top_measurements_indices = &measurements_indices[0..max_measurements_for_combos];
 
-    for combo in top_closest_measurements_indices
-        .iter()
-        .combinations(sample_size)
-    {
+    for combo in top_measurements_indices.iter().combinations(sample_size) {
         let mut sample: Vec<Measurement> =
             combo.iter().map(|index| measurements[**index]).collect();
 

--- a/interop/position-estimation_rust/src/lib.rs
+++ b/interop/position-estimation_rust/src/lib.rs
@@ -169,7 +169,7 @@ mod tests {
                 z: Coordinate::new_real(z, z_variance),
             },
             distance,
-            probability: 0.0,
+            weight: 0.0,
         }
     }
 

--- a/interop/position-estimation_rust/src/lib.rs
+++ b/interop/position-estimation_rust/src/lib.rs
@@ -89,7 +89,9 @@ pub fn estimate_position(measurements: &[Measurement]) -> Option<EstimatedPositi
             let standard_deviation = (measurement.position.x.variance
                 + measurement.position.y.variance
                 + measurement.position.z.variance)
-                .sqrt();
+                .sqrt()
+                // Prevent division by zero.
+                .max(f64::MIN);
             let standardized_residual = residual / standard_deviation;
             // within 2 standard deviations
             let threshold = 2.0;

--- a/interop/position-estimation_rust/src/measurement.rs
+++ b/interop/position-estimation_rust/src/measurement.rs
@@ -9,6 +9,6 @@ pub struct Measurement {
     pub position: Position,
     /// estimated distance away from device
     pub distance: f64,
-    /// probability of measurement
-    pub probability: f64,
+    /// weight of measurement
+    pub weight: f64,
 }

--- a/interop/position-estimation_rust/src/multilateration.rs
+++ b/interop/position-estimation_rust/src/multilateration.rs
@@ -21,7 +21,7 @@ pub fn multilateration(
             .choose(random)
             .expect("should be given at least 1 measurement");
 
-        // E step: compare difference between estimated position and measurement position and distance to get a probability
+        // E step: compare difference between estimated position and measurement position and distance to get a weight
         let mut delta_update = Position::default();
 
         let x_delta = estimated_position.x.value - measurement.position.x.value;
@@ -30,7 +30,7 @@ pub fn multilateration(
 
         let estimated_distance = (x_delta.powi(2) + y_delta.powi(2) + z_delta.powi(2)).sqrt();
 
-        measurement.probability = if (measurement.distance - estimated_distance).abs()
+        measurement.weight = if (measurement.distance - estimated_distance).abs()
             > (measurement.position.x.variance
                 + measurement.position.y.variance
                 + measurement.position.z.variance)
@@ -42,10 +42,10 @@ pub fn multilateration(
             0.0
         };
 
-        // M step: adjust estimated position to fit the point to a degree based on the probability
-        let weight_x = measurement.probability;
-        let weight_y = measurement.probability;
-        let weight_z = measurement.probability;
+        // M step: adjust estimated position to fit the point to a degree based on the weight
+        let weight_x = measurement.weight;
+        let weight_y = measurement.weight;
+        let weight_z = measurement.weight;
 
         delta_update.x.value = x_delta * weight_x;
         delta_update.y.value = y_delta * weight_y;
@@ -76,7 +76,7 @@ pub fn multilateration(
     let mut weighted_variance_z = 0.0;
 
     for measurement in measurements {
-        let weight = measurement.probability + 1.0;
+        let weight = measurement.weight + 1.0;
 
         weighted_variance_x += weight * (measurement.position.x.variance);
         weighted_variance_y += weight * (measurement.position.y.variance);

--- a/interop/position-estimation_rust/src/multilateration.rs
+++ b/interop/position-estimation_rust/src/multilateration.rs
@@ -15,7 +15,7 @@ pub fn multilateration(
 ) -> Position {
     let mut estimated_position = initial_guess.unwrap_or_default();
 
-    for _ in 0..iterations {
+    for iter_index in 0..iterations {
         let measurement = measurements
             .iter_mut()
             .choose(random)
@@ -43,9 +43,11 @@ pub fn multilateration(
         };
 
         // M step: adjust estimated position to fit the point to a degree based on the weight
-        let weight_x = measurement.weight;
-        let weight_y = measurement.weight;
-        let weight_z = measurement.weight;
+        let learning_rate = 1.0 - (iter_index as f64 / iterations as f64);
+
+        let weight_x = measurement.weight * learning_rate;
+        let weight_y = measurement.weight * learning_rate;
+        let weight_z = measurement.weight * learning_rate;
 
         delta_update.x.value = x_delta * weight_x;
         delta_update.y.value = y_delta * weight_y;

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -28,10 +28,13 @@ import app.grapheneos.networklocation.wifi.WifiApPositioningData
 import app.grapheneos.networklocation.wifi.WifiApRanger
 import app.grapheneos.networklocation.wifi.WifiApScanner
 import app.grapheneos.networklocation.wifi.WifiPositioningServiceCache
+import app.grapheneos.networklocation.wifi.WifiRangerFailedException
+import app.grapheneos.networklocation.wifi.WifiRangerUnavailableException
 import app.grapheneos.networklocation.wifi.WifiScanFailedException
 import app.grapheneos.networklocation.wifi.WifiScannerUnavailableException
 import app.grapheneos.verboseLog
 import java.io.IOException
+import kotlin.math.absoluteValue
 import kotlin.math.max
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -163,53 +166,60 @@ class LocationReportingTask(
             return null
         }
 
-        runBlocking {
-            // TODO: use Wi-Fi RTT to estimate distance with RSSI as a fallback
-//            try {
-//                // TODO: maybe handle the fact that the max results this can return is 10
-//                wifiRanger.range(bestResults.values.map { it.scanResult }, request.workSource)
-//                    .map { rangingResult ->
-//                        // TODO: handle one-sided RTT correctly
-//                        // use absolute value to counter negative distance values in cases of
-//                        // close devices
-//                        val distanceMeters = rangingResult.distanceMm.absoluteValue / 1000.0
-//
-//                        bestResults[rangingResult.macAddress.toString()]?.estimatedDistance =
-//                            distanceMeters
-//                    }
-//            } catch (e: Exception) {
-//                when (e) {
-//                    is WifiRangerUnavailableException, is WifiRangerFailedException -> {
-//                        // stack trace is intentionally omitted, it doesn't contain useful info
-//                        Log.d(TAG, e.toString())
-//                    }
-//
-//                    else -> throw e
-//                }
-//                verboseLog(TAG) { "falling back to RSSI for estimating distance" }
-                for (result in bestResults.values) {
-                    val pathLossExponent = when (result.scanResult.band) {
-                        ScanResult.WIFI_BAND_24_GHZ -> 4.0
-                        ScanResult.WIFI_BAND_5_GHZ -> 3.75
-                        ScanResult.WIFI_BAND_6_GHZ -> 3.75
-                        else -> continue
+        // TODO: Use Wi-Fi RTT to estimate distance for APs that support it.
+        val useWifiRtt = false
+        if (useWifiRtt) {
+            runBlocking {
+                try {
+                    // TODO: Note that the max results this can return is 10.
+                    wifiRanger.range(bestResults.values.map { it.scanResult }, request.workSource)
+                        .map { rangingResult ->
+                            // TODO: Handle one-sided RTT correctly or stop using it.
+                            // use absolute value to counter negative distance values in cases of
+                            // close devices
+                            val distanceMeters = rangingResult.distanceMm.absoluteValue / 1000.0
+                            val varianceMeters = (rangingResult.distanceStdDevMm / 1000.0).pow(2.0)
+
+                            // verboseLog(TAG) { "$rangingResult, $distanceMeters, $varianceMeters" }
+
+                            bestResults[rangingResult.macAddress.toString()]?.estimatedDistance =
+                                EstimatedDistance(distanceMeters, varianceMeters)
+                        }
+                } catch (e: Exception) {
+                    when (e) {
+                        is WifiRangerUnavailableException, is WifiRangerFailedException -> {
+                            // stack trace is intentionally omitted, it doesn't contain useful info
+                            Log.d(TAG, e.toString())
+                        }
+
+                        else -> throw e
                     }
-                    val rssiAtOneMeter = when (result.scanResult.band) {
-                        ScanResult.WIFI_BAND_24_GHZ -> -20.0
-                        ScanResult.WIFI_BAND_5_GHZ -> -35.0
-                        ScanResult.WIFI_BAND_6_GHZ -> -35.0
-                        else -> continue
-                    }
-                    result.estimatedDistance = EstimatedDistance(
-                        rssiToDistance(
-                            result.scanResult.level.toDouble(),
-                            pathLossExponent,
-                            rssiAtOneMeter,
-                        ),
-                        max(0.0, rssiAtOneMeter - result.scanResult.level.toDouble()).pow(2)
-                    )
                 }
-//            }
+            }
+        }
+
+        // Only use RSSI estimation on results with non-null estimatedDistance (not set by Wi-Fi RTT).
+        for (result in bestResults.values.filter { it.estimatedDistance == null }) {
+            val pathLossExponent = when (result.scanResult.band) {
+                ScanResult.WIFI_BAND_24_GHZ -> 4.0
+                ScanResult.WIFI_BAND_5_GHZ -> 3.75
+                ScanResult.WIFI_BAND_6_GHZ -> 3.75
+                else -> continue
+            }
+            val rssiAtOneMeter = when (result.scanResult.band) {
+                ScanResult.WIFI_BAND_24_GHZ -> -20.0
+                ScanResult.WIFI_BAND_5_GHZ -> -35.0
+                ScanResult.WIFI_BAND_6_GHZ -> -35.0
+                else -> continue
+            }
+            result.estimatedDistance = EstimatedDistance(
+                rssiToDistance(
+                    result.scanResult.level.toDouble(),
+                    pathLossExponent,
+                    rssiAtOneMeter,
+                ),
+                max(0.0, rssiAtOneMeter - result.scanResult.level.toDouble()).pow(2)
+            )
         }
 
         bestResults =


### PR DESCRIPTION
Some more position estimation improvements:

- Adding a learning rate to the multilateration algorithm improves accuracy and stability as the estimated position has time to "settle down". 
- Using the lowest standard deviation instead of the closest for determining which measurements to use for combos also improves accuracy and stability.
- Prevent potential division by zero when calculating standardized residual
- Renamed misleading Measurement.probability to weight

Also: Improve WIP Wi-Fi RTT support and uncomment the code, instead keeping it behind a boolean flag to prevent breakage and allow easy testing. It's still disabled.

Changes tested in various environments to make sure no regressions were introduced. When running the on-device unit tests, there is an overall increase in accuracy from ~90 to ~70.