### PR TITLE
change geocoder GrapheneOS proxy to server and Nominatim server to OpenStreetMaps

### DIFF
--- a/src/app/grapheneos/geocoder/GeocodeProviderImpl.kt
+++ b/src/app/grapheneos/geocoder/GeocodeProviderImpl.kt
@@ -2,8 +2,8 @@ package app.grapheneos.geocoder
 
 import android.content.Context
 import android.ext.settings.GeocoderSettings.GEOCODER_DISABLED
-import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_GRAPHENEOS_PROXY
-import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_NOMINATIM
+import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_GRAPHENEOS
+import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_OPENSTREETMAPS
 import android.ext.settings.GeocoderSettings.GEOCODER_SETTING
 import android.location.Address
 import android.location.provider.ForwardGeocodeRequest
@@ -80,7 +80,7 @@ class GeocodeProviderImpl(private val context: Context) : GeocodeProviderBase(co
     private fun getGeocoder(): Geocoder {
         val setting = GEOCODER_SETTING.get(context)
         return when (setting) {
-            GEOCODER_SERVER_GRAPHENEOS_PROXY, GEOCODER_SERVER_NOMINATIM -> NominatimGeocoder()
+            GEOCODER_SERVER_GRAPHENEOS, GEOCODER_SERVER_OPENSTREETMAPS -> NominatimGeocoder()
 
             GEOCODER_DISABLED -> throw IOException("geocoder setting is disabled")
 

--- a/src/app/grapheneos/geocoder/NominatimGeocoder.kt
+++ b/src/app/grapheneos/geocoder/NominatimGeocoder.kt
@@ -3,8 +3,8 @@ package app.grapheneos.geocoder
 import android.app.AppGlobals
 import android.content.Context
 import android.ext.settings.GeocoderSettings.GEOCODER_DISABLED
-import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_GRAPHENEOS_PROXY
-import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_NOMINATIM
+import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_GRAPHENEOS
+import android.ext.settings.GeocoderSettings.GEOCODER_SERVER_OPENSTREETMAPS
 import android.ext.settings.GeocoderSettings.GEOCODER_SETTING
 import android.location.Address
 import android.os.Bundle
@@ -193,9 +193,9 @@ class NominatimGeocoder : Geocoder {
         val context: Context = AppGlobals.getInitialApplication()
         val setting = GEOCODER_SETTING.get(context)
         return when (setting) {
-            GEOCODER_SERVER_GRAPHENEOS_PROXY -> Pair(URL("https://nominatim.grapheneos.org"), true)
+            GEOCODER_SERVER_GRAPHENEOS -> Pair(URL("https://nominatim.grapheneos.org"), true)
 
-            GEOCODER_SERVER_NOMINATIM -> Pair(URL("https://nominatim.openstreetmap.org"), true)
+            GEOCODER_SERVER_OPENSTREETMAPS -> Pair(URL("https://nominatim.openstreetmap.org"), true)
 
             GEOCODER_DISABLED ->
                 // geocoder can be disabled by the user at any point


### PR DESCRIPTION
Changeset:
https://github.com/GrapheneOS/platform_frameworks_base/pull/322
https://github.com/GrapheneOS/platform_packages_apps_NetworkLocation/pull/31
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/415

We now have our own self-hosted Nominatim instance.