### PR TITLE
audit fixes: division-by-zero guard, executor leak, log typo

### DIFF
--- a/interop/position-estimation_rust/src/lib.rs
+++ b/interop/position-estimation_rust/src/lib.rs
@@ -91,7 +91,7 @@ pub fn estimate_position(measurements: &[Measurement]) -> Option<EstimatedPositi
                 + measurement.position.z.variance)
                 .sqrt()
                 // Prevent division by zero.
-                .max(f64::MIN);
+                .max(f64::MIN_POSITIVE);
             let standardized_residual = residual / standard_deviation;
             // within 2 standard deviations
             let threshold = 2.0;

--- a/src/app/grapheneos/geocoder/GeocodeProviderImpl.kt
+++ b/src/app/grapheneos/geocoder/GeocodeProviderImpl.kt
@@ -23,7 +23,7 @@ class GeocodeProviderImpl(private val context: Context) : GeocodeProviderBase(co
     ) {
         verboseLog(TAG) {
             "forward geocode parameters: locationName: ${request.locationName}, " +
-                    "lowerLeftLatitude: ${request.lowerLeftLongitude}, lowerLeftLongitude: ${request.lowerLeftLongitude}, " +
+                    "lowerLeftLatitude: ${request.lowerLeftLatitude}, lowerLeftLongitude: ${request.lowerLeftLongitude}, " +
                     "upperRightLatitude: ${request.upperRightLatitude}, upperrightlongitude: ${request.upperRightLongitude}, " +
                     "maxResults: ${request.maxResults}, locale: ${request.locale}"
         }

--- a/src/app/grapheneos/networklocation/wifi/WifiApRanger.kt
+++ b/src/app/grapheneos/networklocation/wifi/WifiApRanger.kt
@@ -8,6 +8,7 @@ import android.net.wifi.rtt.RangingResultCallback
 import android.net.wifi.rtt.WifiRttManager
 import android.os.WorkSource
 import app.grapheneos.verboseLog
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -19,6 +20,7 @@ private const val TAG = "WifiApRanger"
  * TODO: WIP Wi-Fi RTT AP ranger, not currently used.
  */
 class WifiApRanger(private val context: Context) {
+    private val rangingExecutor: ExecutorService = Executors.newSingleThreadExecutor()
 
     @Throws(WifiRangerUnavailableException::class, WifiRangerFailedException::class)
     suspend fun range(scanResults: List<ScanResult>, workSource: WorkSource): List<RangingResult> {
@@ -51,16 +53,16 @@ class WifiApRanger(private val context: Context) {
                 }
             }
             verboseLog(TAG) { "calling startRanging" }
-            val executor = Executors.newSingleThreadExecutor()
             wifiRttManager.startRanging(
                 workSource,
                 request,
-                executor,
+                rangingExecutor,
                 rangingResultCallback
             )
             continuation.invokeOnCancellation {
                 verboseLog(TAG) {"cancelling ranging"}
                 wifiRttManager.cancelRanging(workSource)
+                rangingExecutor.shutdownNow()
                 verboseLog(TAG) {"canceled ranging"}
             }
         }


### PR DESCRIPTION
Three independent fixes from a code audit. Each is in its own commit.

**fix division-by-zero guard in inlier check**

In lib.rs, the standardized-residual computation guarded against division by zero with .max(f64::MIN). f64::MIN is the most-negative finite value (≈ -1.8e308), not the smallest positive one, so the clamp was a no-op for any non-negative sqrt result. When all three variances are zero, standard_deviation stayed zero and residual / standard_deviation produced inf (or NaN if residual was also zero), causing the comparison <= 2.0 to fail and the measurement to never count as an inlier, the opposite of the comment's stated intent. Replaced with f64::MIN_POSITIVE.

**stop leaking an executor per WifiApRanger.range() call**

WifiApRanger.range() created a fresh Executors.newSingleThreadExecutor() inside the suspend lambda and never shut it down — neither on success nor in invokeOnCancellation. Each successful call leaked a non-daemon worker thread. Hoisted the executor to an instance field and shut it down on cancellation, matching the existing pattern in CellTowerScanner. Currently latent because Wi-Fi RTT is gated behind useWifiRtt = false in LocationReportingTask, but worth fixing before re-enabling.

**fix latitude/longitude mixup in forward geocode log**

The forward geocode parameters verbose log in GeocodeProviderImpl printed request.lowerLeftLongitude for both the latitude and longitude fields. Cosmetic; only affects debug output.