### PR TITLE
Fix cell-based location accuracy and geocoder robustness

### DIFF
--- a/src/app/grapheneos/geocoder/GeocodeProviderImpl.kt
+++ b/src/app/grapheneos/geocoder/GeocodeProviderImpl.kt
@@ -23,8 +23,8 @@ class GeocodeProviderImpl(private val context: Context) : GeocodeProviderBase(co
     ) {
         verboseLog(TAG) {
             "forward geocode parameters: locationName: ${request.locationName}, " +
-                    "lowerLeftLatitude: ${request.lowerLeftLongitude}, lowerLeftLongitude: ${request.lowerLeftLongitude}, " +
-                    "upperRightLatitude: ${request.upperRightLatitude}, upperrightlongitude: ${request.upperRightLongitude}, " +
+                    "lowerLeftLatitude: ${request.lowerLeftLatitude}, lowerLeftLongitude: ${request.lowerLeftLongitude}, " +
+                    "upperRightLatitude: ${request.upperRightLatitude}, upperRightLongitude: ${request.upperRightLongitude}, " +
                     "maxResults: ${request.maxResults}, locale: ${request.locale}"
         }
         try {

--- a/src/app/grapheneos/geocoder/NominatimGeocoder.kt
+++ b/src/app/grapheneos/geocoder/NominatimGeocoder.kt
@@ -139,12 +139,17 @@ class NominatimGeocoder : Geocoder {
         }
         val result = mutableListOf<Address>()
         for (feature in response.features?.take(expectedMaxResults) ?: emptyList()) {
+            val coordinates = feature.geometry.coordinates
+            if (coordinates.size < 2) {
+                Log.w(TAG, "skipping feature with invalid coordinates size: ${coordinates.size}")
+                continue
+            }
             val extra = feature.properties.geocoding.extra?.toMutableMap()
             // we don't know which locale was actually used, so we just assume it was the one
             // we requested
             val address = Address(preferredLocale)
-            address.latitude = feature.geometry.coordinates[1]
-            address.longitude = feature.geometry.coordinates[0]
+            address.latitude = coordinates[1]
+            address.longitude = coordinates[0]
             with(feature.properties.geocoding) {
                 address.postalCode = this.postcode
                 address.featureName = this.name

--- a/src/app/grapheneos/networklocation/LocationReportingTask.kt
+++ b/src/app/grapheneos/networklocation/LocationReportingTask.kt
@@ -540,10 +540,14 @@ class LocationReportingTask(
         val estimatedGeoPoint = enuPointToGeoPoint(enuPoint, refGeoPoint)
         loc.longitude = estimatedGeoPoint.longitude
         loc.latitude = estimatedGeoPoint.latitude
-        loc.accuracy = sqrt(max(result.x.sixSigmaSquared, result.y.sixSigmaSquared)).toFloat()
+        val accuracySixSigma = sqrt(max(result.x.sixSigmaSquared, result.y.sixSigmaSquared))
+        // Convert from 6-sigma to 1-sigma
+        loc.accuracy = accuracySixSigma.div(6.0).toFloat()
         estimatedGeoPoint.altitude?.let { estimatedAltitude ->
             loc.altitude = estimatedAltitude
-            loc.verticalAccuracyMeters = sqrt(result.z.sixSigmaSquared).toFloat()
+            val verticalAccuracySixSigma = sqrt(result.z.sixSigmaSquared)
+            // Convert from 6-sigma to 1-sigma
+            loc.verticalAccuracyMeters = verticalAccuracySixSigma.div(6.0).toFloat()
         }
         return loc
     }

--- a/src/app/grapheneos/networklocation/wifi/WifiApRanger.kt
+++ b/src/app/grapheneos/networklocation/wifi/WifiApRanger.kt
@@ -8,6 +8,7 @@ import android.net.wifi.rtt.RangingResultCallback
 import android.net.wifi.rtt.WifiRttManager
 import android.os.WorkSource
 import app.grapheneos.verboseLog
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -19,6 +20,7 @@ private const val TAG = "WifiApRanger"
  * TODO: WIP Wi-Fi RTT AP ranger, not currently used.
  */
 class WifiApRanger(private val context: Context) {
+    private val rangingExecutor: ExecutorService = Executors.newSingleThreadExecutor()
 
     @Throws(WifiRangerUnavailableException::class, WifiRangerFailedException::class)
     suspend fun range(scanResults: List<ScanResult>, workSource: WorkSource): List<RangingResult> {
@@ -51,11 +53,10 @@ class WifiApRanger(private val context: Context) {
                 }
             }
             verboseLog(TAG) { "calling startRanging" }
-            val executor = Executors.newSingleThreadExecutor()
             wifiRttManager.startRanging(
                 workSource,
                 request,
-                executor,
+                rangingExecutor,
                 rangingResultCallback
             )
             continuation.invokeOnCancellation {


### PR DESCRIPTION
- report cell-based location accuracy as 1-sigma: the Wi-Fi path divides the 6-sigma estimate by 6 to report the 1-sigma accuracy Location expects, but the cell path reported the raw 6-sigma value, so cell-based fixes reported a radius 6 times too large.

- skip geocoder features with fewer than two coordinates: an empty or single-element coordinates array threw IndexOutOfBoundsException, which is not an IOException and escaped the handler in GeocodeProviderImpl, leaving the request callback uncompleted.

- reuse a single executor in WifiApRanger: each range() call created a new single-thread executor that was only reclaimed by finalization.

- fix forward geocode parameter logging: lowerLeftLatitude logged the longitude value and the upperRightLongitude label was miscased.