### PR TITLE
use unsafe(no_mangle) for the JNI entry point

### DIFF
--- a/interop/position-estimation_rust/src/jni.rs
+++ b/interop/position-estimation_rust/src/jni.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 // SAFETY: There is no other global function of this name.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_app_grapheneos_networklocation_interop_position_1estimation_PositionEstimation_estimatePosition(
     mut env: JNIEnv,
     _class: JClass,


### PR DESCRIPTION
The unsafe(no_mangle) attribute form is stable since Rust 1.82 and required by edition 2024; it marks the soundness obligation (no other symbol may share the name) explicitly at the declaration. The platform toolchain builds this module with Rust 1.93.1 on edition 2021, where both forms compile, so this is forward-compatible cleanup with no behavior change.